### PR TITLE
fix(layout): improve responsive docs sidebar, toc, and breadcrumb spacing

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -141,6 +141,14 @@ small,
   }
 }
 
+.td-sidebar__inner {
+  padding-top: 0.75rem;
+}
+
+.td-breadcrumbs {
+  padding-top: 0.75rem;
+}
+
 .td-sidebar-toc {
   background-color: var(--color-bg-white);
 }
@@ -150,6 +158,14 @@ small,
 @media (min-width: 1200px) {
   .td-main > .row.flex-xl-nowrap {
     align-items: stretch;
+  }
+
+  .td-sidebar__inner {
+    padding-top: 1rem;
+  }
+
+  .td-breadcrumbs {
+    padding-top: 1rem;
   }
 
   .td-main > .row.flex-xl-nowrap > .td-sidebar,


### PR DESCRIPTION
**Description**:
Improve the docs page layout across wide, tablet, and mobile breakpoints so sidebar, ToC, breadcrumbs, and main content stay visually balanced and readable without layout gaps or wrapping regressions.

- Balance the left navigation and right ToC columns on xl screens using responsive widths
- Let the main content column flex to consume remaining horizontal space on widescreens
- Add explicit ToC background coverage so the right-side gap does not appear on wide displays
- Remove the fixed .td-sidebar width that broke layout flow below 1200px
- Remove forced .td-sidebar-toc top padding that introduced a visible top seam and contributed to the sub-1200px regression
- Add mobile-only horizontal gutters for main content below 768px to improve readability on narrow screens
- Add matching mobile gutter spacing to breadcrumbs so they align with the content column
- Add top padding to the sidebar inner container so the Docs navigation does not visually stick to the top
- Add matching top padding to breadcrumbs so they align horizontally with the sidebar start position
- Preserve responsive behavior across breakpoints without changing content structure or page semantics

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This PR only updates assets/scss/_styles_project.scss.

Suggested review focus:

1. &gt;= 1200px
  - left sidebar and right ToC should appear balanced
  - main content should expand naturally between them
  - no visible gap should remain to the right of the ToC, especially in dark mode

2. 768px - 1199px
  - layout should follow Docsy’s normal responsive flow without the main content dropping below the sidebar unexpectedly

3. < 768px
  - main content and breadcrumbs should have improved left/right breathing room
  - docs navigation should have visible top spacing

4. Breadcrumb/sidebar alignment
  - the top of the breadcrumb block should visually align with the top of the sidebar navigation

This is a styling-only change. No templates, content, or runtime logic were modified.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
