### PR TITLE
docs(package.json): fix docsy dependency retrieval command for module version validity

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit --allow-empty -m \"Site at $HASH\"",
     "_diff:check": "git diff --name-only --exit-code",
     "_fix:permissions": "chmod -R u+w public/* 2>/dev/null || true",
-    "_get:docsy": "hugo mod get github.com/google/docsy@v$npm_package_version",
+    "_get:docsy": "hugo mod get -u github.com/google/docsy",
     "_hugo-dev": "npm run _hugo -- -e dev --logLevel info -DFE",
     "_hugo": "hugo --cleanDestinationDir",
     "_local": "npx cross-env HUGO_MODULE_WORKSPACE=docsy.work",


### PR DESCRIPTION
### Description:
**Problem:** 
`npm_package_version` (0.0.0) was invalid for Hugo module
**Root Cause:** 
`_get:docsy` script used `@v$npm_package_version` → `@v0.0.0`
**Solution:** 
Changed to `hugo mod get -u github.com/google/docsy`
**Status:** 
Fixed in `package.json` and verified

**Related issue(s)**:

Related to #26 

**Notes for reviewer**:
This change patches production build and minification related rendering errors for Hugo due to incorrect Docsy module version resolution

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
