### PR TITLE
feat(search): implement typeahead functionality for offline search input

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -17,3 +17,59 @@
     }
   })();
 </script>
+
+<script>
+  // Enable typeahead behavior for Docsy offline search.
+  // Docsy binds search rendering to the "change" event (Enter/blur), so we
+  // dispatch debounced "change" events while typing.
+  (function () {
+    function enableTypeaheadSearch() {
+      if (!window.jQuery) {
+        return;
+      }
+
+      var $ = window.jQuery;
+      var debounceMs = 150;
+
+      $('.td-search input').each(function () {
+        var $input = $(this);
+
+        if ($input.data('typeaheadBound')) {
+          return;
+        }
+
+        $input.data('typeaheadBound', true);
+
+        var timerId = null;
+
+        $input.on('input', function () {
+          var el = this;
+
+          if (timerId) {
+            clearTimeout(timerId);
+          }
+
+          timerId = setTimeout(function () {
+            // Avoid Docsy's default "change" handler forcibly blurring input.
+            var originalBlur = $.fn.blur;
+            $.fn.blur = function () {
+              return this;
+            };
+
+            try {
+              $(el).trigger('change');
+            } finally {
+              $.fn.blur = originalBlur;
+            }
+          }, debounceMs);
+        });
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', enableTypeaheadSearch);
+    } else {
+      enableTypeaheadSearch();
+    }
+  })();
+</script>


### PR DESCRIPTION
**Description**:
Enable live typeahead search for the Docsy offline (Lunr.js) search input so results appear as the user types instead of requiring Enter or a focus-blur cycle to trigger rendering.

Docsy's upstream offline search implementation binds its Lunr rendering function to the `change` event on the search input. This means results only render on Enter or when the input loses focus, which is a poor UX pattern for a documentation reference site where users expect instant results as they type.

- Add a `debounced` input event listener on `.td-search input` in the body-end hook partial that programmatically triggers the upstream Docsy `change` handler with a 150 ms debounce
- Guard against double-binding by tracking bound state via a jQuery data attribute so the listener is never attached twice
- Patch jQuery's `.blur()` method transiently during the synthetic `change` trigger so Docsy's built-in blur side-effect does not steal keyboard focus while the user is still typing
- Restore the original `.blur()` implementation immediately in a `finally` block so no other component is affected

**Related issue(s)**:

Fixes #60 

**Notes for reviewer**:

- No upstream Docsy files are modified. The change is entirely contained in `body-end.html`, which Hugo injects at the end of every page's `<body>`. This means the change works across all pages (docs, search, landing) without any structural risk.
- The 150 ms debounce is a balance between perceived instant response and avoiding redundant Lunr index queries on every keystroke. It can be tuned by changing `debounceMs`.
- The existing Enter/blur behavior is preserved — users who still press Enter will get results via the normal `change` path.
- The blur suppression is a narrow, transient patch scoped only to the duration of the synthetic `change` dispatch. It should not affect any Bootstrap dropdowns, modals, or other jQuery-dependent components.
- Suggested manual test flow: open any page, click the search box in the navbar, start typing (e.g. `deploy`): the Lunr results popover should appear and update within ~150 ms per keystroke without pressing Enter.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (Manually tested)
