### PR TITLE
docs(site): add prev/next page navigation and fix markdown lint errors

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -205,6 +205,58 @@ main a {
   }
 }
 
+.td-docs-page-nav__inner {
+  align-items: stretch;
+}
+
+.td-docs-page-nav {
+  margin-bottom: 0;
+}
+
+.td-docs-page-nav__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  width: 100%;
+  padding: 0.25rem 0 0.4rem;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+}
+
+.td-docs-page-nav + .td-page-meta__lastmod {
+  margin-top: 0.5rem !important;
+  padding-top: 0 !important;
+}
+
+.td-docs-page-nav__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-light);
+}
+
+.td-docs-page-nav__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-dark);
+}
+
+@media (min-width: 768px) {
+  .td-docs-page-nav__link {
+    width: calc(50% - 0.5rem);
+  }
+
+  .td-docs-page-nav__link--next {
+    margin-left: auto;
+    align-items: flex-end;
+    text-align: right;
+  }
+}
+
 // External Link Indicator
 a[target='_blank']::after {
   content: ' \f35d';

--- a/content/en/docs/advanced-solo-setup/jvm-debugger/_index.md
+++ b/content/en/docs/advanced-solo-setup/jvm-debugger/_index.md
@@ -331,5 +331,3 @@ solo consensus node states -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}
 # Restart the network using the uploaded state
 solo consensus node start --deployment "${SOLO_DEPLOYMENT}" --state-file network-node1-0-state.zip
 ```
-
----

--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
@@ -421,5 +421,3 @@ In practice:
 > This file includes all supported sections and flags with inline comments
 > explaining each option. Copy it, remove what you do not need, and adjust the
 > values for your environment.
-
----

--- a/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
@@ -638,5 +638,3 @@ solo consensus network destroy \
   --deployment "${SOLO_DEPLOYMENT}" \
   --force
 ```
-
----

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -307,5 +307,3 @@ The mirror node accumulates transaction history while the network is running. If
     ```
 
 - Then run `k9s` to launch. It is especially helpful for watching pod startup progress during deployment.
-
----

--- a/content/en/docs/troubleshooting.md
+++ b/content/en/docs/troubleshooting.md
@@ -424,5 +424,3 @@ Join the community for discussions and help:
 
 - **Hedera Discord**: Look for the `#solo` channel
 - **Hiero Community**: <https://hiero.org/community>
-
----

--- a/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
+++ b/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
@@ -14,10 +14,10 @@ type: docs
 The Hiero Mirror Node stores the full transaction history of your local Solo network
 and exposes it through several interfaces:
 
-  - A **web-based block explorer** (Hiero Mirror Node Explorer) at `http://localhost:8080`.
-  - A **REST API** via the mirror-ingress service at `http://localhost:8081`
+- A **web-based block explorer** (Hiero Mirror Node Explorer) at `http://localhost:8080`.
+- A **REST API** via the mirror-ingress service at `http://localhost:8081`
     (recommended entry point-routes to the correct REST implementation).
-  - A **gRPC endpoint** for mirror node subscriptions.
+- A **gRPC endpoint** for mirror node subscriptions.
 
 This guide walks you through adding Mirror Node and the Hiero Explorer to a
 Solo network, and shows you how to query transaction data and create accounts.
@@ -37,6 +37,7 @@ Before proceeding, ensure you have completed the following:
   ```bash
   cat ~/.solo/cache/last-one-shot-deployment.txt
   ```
+
 ---
 
 ## Step 1: Deploy Solo with Mirror Node
@@ -47,7 +48,6 @@ Before proceeding, ensure you have completed the following:
 > or the [Task Tool](/docs/advanced-solo-setup/customizing-solo-with-tasks),
 > Mirror Node is already running -
 > skip to [Step 2: Access the Mirror Node Explorer](#step-2-access-the-mirror-node-explorer).
-
 
 ### Fresh manual Deployment
 
@@ -105,8 +105,8 @@ solo explorer node add \
 
 > **Note:** The `--pinger` flag in `solo mirror node add` starts a background
 > service that sends transactions to the network at regular intervals. This is
-> **required** because mirror node record files are only imported when a new 
-> record file is created - without it, the mirror node will appear empty until 
+> **required** because mirror node record files are only imported when a new
+> record file is created - without it, the mirror node will appear empty until
 > the next transaction occurs naturally.
 
 ---
@@ -162,6 +162,7 @@ curl -s "http://localhost:8081/api/v1/accounts/0.0.2"
 > out. Always use `localhost:8081` to ensure compatibility with all endpoints.
 
 If you need to access it directly:
+
   ```bash
   kubectl port-forward svc/mirror-1-rest -n "${SOLO_NAMESPACE}" 5551:80 &
   curl -s "http://${REST_IP:-127.0.0.1}:5551/api/v1/transactions?limit=1"
@@ -200,7 +201,7 @@ In most cases you should use `localhost:8081` instead.
 ## Port Reference
 
 | Service | Local Port | Access Method |
-|---------|------------|---------------|
+| --- | --- | --- |
 | Hiero Explorer | `8080` | Browser (`--enable-ingress`) |
 | Mirror Node (all-in-one) | `8081` | HTTP (`--enable-ingress`) |
 | Mirror Node REST API | `5551` | `kubectl port-forward` |
@@ -217,6 +218,7 @@ them without redeploying:
 ```bash
 solo deployment refresh port-forwards
 ```
+
 ---
 
 ## Tearing Down
@@ -235,7 +237,3 @@ solo explorer node destroy --deployment "${SOLO_DEPLOYMENT}" --force
 
 For full network teardown, see
 [**Step-by-Step Manual Deployment-Cleanup**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#cleanup).
-
----
-
-

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -61,7 +61,7 @@ This command:
 > **Relay endpoint summary:**
 >
 > | Property | Value |
-> |---|---|
+> | --- | --- |
 > | RPC URL | `http://localhost:7546` |
 > | Chain ID | `298` |
 > | Currency symbol | `HBAR` |
@@ -70,17 +70,16 @@ This command:
 
 If you already have a running Solo network without the relay, see [**Step 10: Deploy JSON-RPC Relay**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#10-deploy-json-rpc-relay) in the Step-by-Step Manual Deployment guide for full instructions, then return here once your relay is running on `http://localhost:7546`.
 
-
 To remove the relay when you no longer need it, see [**Cleanup Step 1: Destroy JSON-RPC Relay**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#1-destroy-json-rpc-relay) in the same guide.
 
 ---
 
 ## Step 2: Retrieve Your ECDSA Account and Private Key
 
-`one-shot single deploy` creates ECDSA alias accounts, which are required for EVM tooling such as Hardhat, ethers.js, and MetaMask. 
+`one-shot single deploy` creates ECDSA alias accounts, which are required for EVM tooling such as Hardhat, ethers.js, and MetaMask.
 These accounts and their private keys are saved to a cache directory on completion.
 
-> Note: ED25519 accounts are not compatible with Hardhat, ethers.js, or MetaMask when used via the JSON-RPC interface. 
+> Note: ED25519 accounts are not compatible with Hardhat, ethers.js, or MetaMask when used via the JSON-RPC interface.
 > Always use the ECDSA keys from accounts.json for EVM tooling.
 
 - To find your deployment name, run:
@@ -333,7 +332,7 @@ http://localhost:8081/api/v1/transactions?limit=5
 Returns the five most recent transactions in JSON format. Useful for scripted
 verification.
 
-> Note: `localhost:5551` (the legacy Mirror Node REST API) is being phased out. 
+> Note: `localhost:5551` (the legacy Mirror Node REST API) is being phased out.
 > Always use `localhost:8081` to ensure compatibility with all endpoints.
 
 ### Hiero JSON RPC Relay (eth_getTransactionReceipt)
@@ -355,7 +354,7 @@ To connect MetaMask to your local Solo network:
 2. Enter the following values:
 
    | Field | Value |
-   |---|---|
+   | --- | --- |
    | Network name | `Solo Local` |
    | New RPC URL | `http://localhost:7546` |
    | Chain ID | `298` |
@@ -415,7 +414,7 @@ details.
 ## Troubleshooting
 
 | Symptom | Likely Cause | Fix |
-|---|---|---|
+| --- | --- | --- |
 | `connection refused` on port `7546` | Relay not running | Run `one-shot single deploy` or `solo relay node add` |
 | `invalid sender` or signature error | Using ED25519 key instead of ECDSA | Use ECDSA keys from `accounts.json` |
 | Hardhat `chainId` mismatch error | Missing or wrong `chainId` in config | Set `chainId: 298` in `hardhat.config.ts` |
@@ -431,5 +430,3 @@ details.
 - [Solo deployment with Hardhat Example](/examples/hardhat-with-solo/).
 - [Configuring Hardhat with Hiero Local Node](https://docs.hedera.com/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide) - the Hedera tutorial this guide is modelled on.
 - [Retrieving Logs](/docs/jvm-debugger/) - for debugging network-level issues.
-
----

--- a/content/en/docs/using-solo/using-solo-with-javascript-sdk.md
+++ b/content/en/docs/using-solo/using-solo-with-javascript-sdk.md
@@ -439,5 +439,3 @@ the SDK and your local Solo network.
 | `INSUFFICIENT_TX_FEE` | Operator account has no HBAR | Re-create the account with `--hbar-amount 100` |
 | SDK cannot connect | Solo network not running or Docker not started | Run `task default-with-mirror` and wait for full startup |
 | `HEDERA_NETWORK` not recognized | `.env` not sourced | Run `source .env` before executing example scripts |
-
----

--- a/layouts/docs/_td-content.html
+++ b/layouts/docs/_td-content.html
@@ -1,0 +1,39 @@
+<div class="td-content">
+	<h1>{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<header class="article-meta">
+		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
+		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+			{{ partial "reading-time.html" . -}}
+		{{ end -}}
+	</header>
+	{{ .Render "_td-content-after-header" -}}
+	{{ .Content }}
+	{{ $previous := .NextInSection -}}
+	{{ $next := .PrevInSection -}}
+	{{ if or $previous $next -}}
+	<nav class="td-docs-page-nav border-top mt-5 pt-4" aria-label="Documentation page navigation">
+		<div class="td-docs-page-nav__inner d-flex flex-column flex-md-row gap-3">
+			{{ if $previous -}}
+			<a class="td-docs-page-nav__link td-docs-page-nav__link--prev" href="{{ $previous.RelPermalink }}" rel="prev" aria-label="{{ T "ui_pager_prev" }} - {{ $previous.Title }}">
+				<span class="td-docs-page-nav__label">&larr; {{ T "ui_pager_prev" }}</span>
+				<span class="td-docs-page-nav__title">{{ $previous.Title }}</span>
+			</a>
+			{{ end -}}
+				{{ if $next -}}
+			<a class="td-docs-page-nav__link td-docs-page-nav__link--next" href="{{ $next.RelPermalink }}" rel="next" aria-label="{{ T "ui_pager_next" }} - {{ $next.Title }}">
+				<span class="td-docs-page-nav__label">{{ T "ui_pager_next" }} &rarr;</span>
+				<span class="td-docs-page-nav__title">{{ $next.Title }}</span>
+			</a>
+				{{ end -}}
+		</div>
+	</nav>
+	{{ end -}}
+	{{ partial "feedback.html" . -}}
+	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
+		<br />
+		{{- partial "disqus-comment.html" . -}}
+	{{ end -}}
+	{{ partial "page-meta-lastmod.html" . }}
+</div>
+{{/**/ -}}


### PR DESCRIPTION
**Description**:

Add automatic previous/next page navigation links to all documentation pages and fix markdownlint MD060 table separator style violations.

* Add `layouts/docs/_td-content.html` to override the Docsy docs content template and inject a prev/next navigation block below each page's content
* Add `.td-docs-page-nav*` SCSS rules to `assets/scss/_styles_project.scss` for responsive, link-style navigation (prev left-aligned, next right-aligned on desktop; stacked on mobile)
* Override Docsy's `margin-top: 3rem !important` on `.td-page-meta__lastmod` to reduce the gap between the nav and the last-modified metadata line
* Fix MD060 table separator rows in `solo-with-mirror-node.md` and `using-solo-with-evm-tools.md` to use spaced pipes (`| --- |`) matching the compact style of surrounding table cells
* Remove trailing `\n---\n` horizontal rules from the ends of several docs pages (`jvm-debugger/_index.md`, `falcon-deployment.md`, `manual-deployment.md`, `faqs.md`, `troubleshooting.md`) that were redundant now that the page nav provides a visual section break

<img width="1674" height="953" alt="image" src="https://github.com/user-attachments/assets/5cc5b63e-e3ba-4248-9740-89409bd63fe8" />


**Related issue(s)**:

Relates to #5 

**Notes for reviewer**:

- The nav uses Hugo's `.NextInSection` / `.PrevInSection` with their semantics swapped (`$previous := .NextInSection`, `$next := .PrevInSection`) because Hugo's naming is counter-intuitive relative to reading order.
- The SCSS adjacent-sibling rule `.td-docs-page-nav + .td-page-meta__lastmod` targets only pages that render both the nav and the lastmod block, avoiding any side-effects elsewhere.
- Pages with no neighbours (first/last in a section) render only one link; section index pages (no siblings) render no nav at all.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (Manual Browser based UI Test)