### PR TITLE
docs: Update npm package link from @hashgraph to @hiero-ledger

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -144,7 +144,7 @@ comprehensive documentation, and sensible defaults. Get a working network in min
     <a href="https://discord.com/channels/905194001349627914/1364886813017247775" target="_blank" class="text-white me-4">
       <i class="fab fa-discord fa-2x"></i>
     </a>
-    <a href="https://www.npmjs.com/package/@hashgraph/solo" target="_blank" class="text-white">
+    <a href="https://www.npmjs.com/package/@hiero-ledger/solo" target="_blank" class="text-white">
       <i class="fab fa-npm fa-2x"></i>
     </a>
   </div>

--- a/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
+++ b/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
@@ -97,7 +97,7 @@ breaking changes from newer releases and cause unexpected workflow failures.
     - name: Install Solo CLI
       run: |
         set -euo pipefail
-        npm install -g @hashgraph/solo@0.48.0
+        npm install -g @hiero-ledger/solo@0.68.0
         solo --version
         kind --version
   ```
@@ -156,7 +156,7 @@ The following is the full workflow combining all steps above. Copy this into you
   - name: Install Solo CLI
     run: |
       set -euo pipefail
-      npm install -g @hashgraph/solo@0.48.0
+      npm install -g @hiero-ledger/solo@0.68.0
       solo --version
       kind --version
       

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -40,7 +40,7 @@ Install the latest Solo CLI globally using one of the following methods:
 - **npm** (alternatively, install Solo via npm):
 
   ```bash
-  npm install -g @hashgraph/solo@latest
+  npm install -g @hiero-ledger/solo@latest
   ```
 
 ### Verify the installation

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -89,7 +89,7 @@ Solo supports **macOS**, **Linux**, and **Windows via WSL2**. Select your platfo
 3. Remove existing npm-based installs:
     <!--lint ignore no-undefined-references-->
     ```sh
-    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hashgraph/solo >/dev/null 2>&1 || /bin/true }
+    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hiero-ledger/solo >/dev/null 2>&1 || /bin/true }
     ```
 
 4. Install Solo (this installs all other dependencies automatically):
@@ -148,7 +148,7 @@ Solo supports **macOS**, **Linux**, and **Windows via WSL2**. Select your platfo
 4. Remove existing npm-based installs:
     <!--lint ignore no-undefined-references-->
     ```sh
-    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hashgraph/solo >/dev/null 2>&1 || /bin/true }
+    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hiero-ledger/solo >/dev/null 2>&1 || /bin/true }
     ```
 
 5. Install Solo (this installs all other dependencies automatically):
@@ -206,7 +206,7 @@ Solo supports **macOS**, **Linux**, and **Windows via WSL2**. Select your platfo
 5. Remove existing npm-based installs:
     <!--lint ignore no-undefined-references-->
     ```sh
-    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hashgraph/solo >/dev/null 2>&1 || /bin/true }
+    [[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hiero-ledger/solo >/dev/null 2>&1 || /bin/true }
     ```
 
 6. Install Solo (this installs all other dependencies automatically):
@@ -236,7 +236,7 @@ If you need more control over dependencies or are contributing to Solo developme
 > **Note:** Node.js >= 22.0.0 and Kind must be installed separately before using this method.
 
 ```bash
-npm install -g @hashgraph/solo
+npm install -g @hiero-ledger/solo
 ```
 
 ## Optional Tools

--- a/content/en/docs/troubleshooting.md
+++ b/content/en/docs/troubleshooting.md
@@ -55,7 +55,7 @@ You are likely hitting an installation or upgrade problem if:
    ```bash
    # Remove legacy npm-based Solo (if present)
    if command -v npm >/dev/null 2>&1; then
-     npm uninstall -g @hashgraph/solo || true
+     npm uninstall -g @hiero-ledger/solo || true
    fi
    ```
 

--- a/content/en/docs/using-solo/using-network-load-generator-with-solo.md
+++ b/content/en/docs/using-solo/using-network-load-generator-with-solo.md
@@ -31,7 +31,7 @@ Use the `rapid-fire load start` command to install the NLG Helm chart and
 begin a load test against your deployment.
 
  ```bash
-    npx @hashgraph/solo@latest rapid-fire load start \
+    npx @hiero-ledger/solo@latest rapid-fire load start \
   --deployment <deployment-name> \
   --args '"-c 3 -a 10 -t 60"' \
   --test CryptoTransferLoadTest
@@ -55,7 +55,7 @@ You can run additional load tests in parallel from a separate terminal. Each
 test runs independently against the same deployment:
 
 ```bash
-    npx @hashgraph/solo@latest rapid-fire load start \
+    npx @hiero-ledger/solo@latest rapid-fire load start \
   --deployment <deployment-name> \
   --args '"-c 3 -a 10 -t 60"' \
   --test NftTransferLoadTest
@@ -66,7 +66,7 @@ test runs independently against the same deployment:
 To stop a single running load test before it completes, use the `stop` command:
 
 ```bash
-    npx @hashgraph/solo@latest rapid-fire load stop \
+    npx @hiero-ledger/solo@latest rapid-fire load stop \
   --deployment <deployment-name> \
   --test CryptoTransferLoadTest
 ```
@@ -76,7 +76,7 @@ To stop a single running load test before it completes, use the `stop` command:
 To stop all running load tests and uninstall the NLG Helm chart:
 
 ```bash
-    npx @hashgraph/solo@latest rapid-fire destroy all \
+    npx @hiero-ledger/solo@latest rapid-fire destroy all \
   --deployment <deployment-name>
  ```
 

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -48,7 +48,7 @@ The easiest way to start a Solo network with the relay pre-configured is via
 Hiero Mirror Node Explorer, and the Hiero JSON-RPC relay in a single step:
 
 ```bash
-npx  one-shot single deploy
+npx @hiero-ledger/solo one-shot single deploy
 ```
 
 This command:

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -48,7 +48,7 @@ The easiest way to start a Solo network with the relay pre-configured is via
 Hiero Mirror Node Explorer, and the Hiero JSON-RPC relay in a single step:
 
 ```bash
-npx @hashgraph/solo one-shot single deploy
+npx  one-shot single deploy
 ```
 
 This command:
@@ -377,7 +377,7 @@ the pre-allocated HBAR balance.
 When finished, destroy the Solo deployment and all associated containers:
 
 ```bash
-npx @hashgraph/solo one-shot single destroy
+npx @hiero-ledger/solo one-shot single destroy
 ```
 
 If you added the relay manually to an existing deployment:


### PR DESCRIPTION
## Description

This pull request updates all documentation references from the old npm package `@hashgraph/solo` to the new package name `@hiero-ledger/solo` across multiple guides, setup instructions, and usage examples. This ensures consistency with the new package naming and prevents confusion for users following the documentation.

**Package rename and usage updates:**

* All installation, uninstallation, and usage instructions in documentation files now reference `@hiero-ledger/solo` instead of `@hashgraph/solo` to reflect the package rename. [[1]](diffhunk://#diff-6d254e8fbd6e25556deed8d4cec8425b2cf7ec4e01605008b6aa11568d974b26L100-R100) [[2]](diffhunk://#diff-6d254e8fbd6e25556deed8d4cec8425b2cf7ec4e01605008b6aa11568d974b26L159-R159) [[3]](diffhunk://#diff-b7200a1ca2c2d3e7a1b7ffcab09bada64f1ef298d0f97d79f3f9b3630fa3e482L43-R43) [[4]](diffhunk://#diff-3d7e74c05879ff4b7c596e216e49fa44eca3ba38aabf0b6cc2228a499b4a1fccL92-R92) [[5]](diffhunk://#diff-3d7e74c05879ff4b7c596e216e49fa44eca3ba38aabf0b6cc2228a499b4a1fccL151-R151) [[6]](diffhunk://#diff-3d7e74c05879ff4b7c596e216e49fa44eca3ba38aabf0b6cc2228a499b4a1fccL209-R209) [[7]](diffhunk://#diff-3d7e74c05879ff4b7c596e216e49fa44eca3ba38aabf0b6cc2228a499b4a1fccL239-R239) [[8]](diffhunk://#diff-90b40ae2aa3dcd0148f19c88ae18fdc30f45f58c31e7306c8dbd90aae6a7ee20L58-R58) [[9]](diffhunk://#diff-522b9417970db29e0b1786fbe8816c6712d1465bf43b8c8d373c80d839bcb1c8L34-R34) [[10]](diffhunk://#diff-522b9417970db29e0b1786fbe8816c6712d1465bf43b8c8d373c80d839bcb1c8L58-R58) [[11]](diffhunk://#diff-522b9417970db29e0b1786fbe8816c6712d1465bf43b8c8d373c80d839bcb1c8L69-R69) [[12]](diffhunk://#diff-522b9417970db29e0b1786fbe8816c6712d1465bf43b8c8d373c80d839bcb1c8L79-R79) [[13]](diffhunk://#diff-f1f180e860deaa9c82eefe2a7a7102cc1cfeb159e7271758996b608ccf81cef9L147-R147) [[14]](diffhunk://#diff-6af107c2055abbcf46efdecdba4f38d3c18b151200115a2828d3480693c277c3L380-R380)

**Version bump for CLI install instructions:**

* The recommended version for installation via npm is updated from `@hashgraph/solo@0.48.0` to `@hiero-ledger/solo@0.68.0` in CI workflow documentation. [[1]](diffhunk://#diff-6d254e8fbd6e25556deed8d4cec8425b2cf7ec4e01605008b6aa11568d974b26L100-R100) [[2]](diffhunk://#diff-6d254e8fbd6e25556deed8d4cec8425b2cf7ec4e01605008b6aa11568d974b26L159-R159)

**Minor command usage correction:**

* In one example, the `npx` command for a one-shot deploy was corrected to remove the package name, likely reflecting a change in usage or a documentation fix.

These changes keep the documentation accurate and up-to-date with the current npm package and recommended installation practices.

## Related Issue(s)

Closes #78