### PR TITLE
fix(docs): resolve site links and restore advanced setup pager flow

### DIFF
--- a/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
+++ b/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
@@ -545,8 +545,8 @@ kind delete cluster --name solo-e2e
 
 After deploying a network with Task, explore:
 
-- **[Using the JavaScript SDK](/docs/using-solo/javascript-sdk)**: Interact with your network programmatically
-- **[Using Network Load Generator](/docs/using-solo/solo-with-network-load-generator)**: Stress test your network
+- **[Using the JavaScript SDK](/docs/using-solo/using-solo-with-javascript-sdk)**: Interact with your network programmatically
+- **[Using Network Load Generator](/docs/using-solo/using-network-load-generator-with-solo)**: Stress test your network
 - **[Environment Variables Reference](/docs/advanced-solo-setup/using-environment-variables)**: Fine-tune deployment behavior
 - **[Solo CI Workflow](/docs/advanced-solo-setup/solo-ci-workflow)**: Integrate Solo deployments into CI/CD pipelines
 

--- a/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
+++ b/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
@@ -6,6 +6,7 @@ description: >
 categories: ["Advanced", "Deployment"]
 tags: ["advanced", "operator", "tasks", "deployment"]
 type: docs
+nav_prev: /docs/advanced-solo-setup/jvm-debugger/
 ---
 
 ## Overview

--- a/content/en/docs/advanced-solo-setup/jvm-debugger/_index.md
+++ b/content/en/docs/advanced-solo-setup/jvm-debugger/_index.md
@@ -8,6 +8,8 @@ description: >
 categories: ["Advanced"]
 tags: ["advanced", "developer", "jvm", "debugging"]
 type: docs
+nav_prev: /docs/advanced-solo-setup/network-deployments/consensus-node-operations/
+nav_next: /docs/advanced-solo-setup/customizing-solo-with-tasks/
 ---
 
 ## Overview

--- a/content/en/docs/advanced-solo-setup/network-deployments/_index.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/_index.md
@@ -8,5 +8,7 @@ description: >-
 categories: ["Advanced", "Deployment"]
 tags: ["advanced", "operator", "deployment", "manual-deployment"]
 weight: 2
+nav_prev: /docs/advanced-solo-setup/using-environment-variables/
+nav_next: /docs/advanced-solo-setup/jvm-debugger/
 ---
 

--- a/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
@@ -8,6 +8,7 @@ description: >
 categories: ["Advanced", "Operations"]
 tags: ["advanced", "operator", "consensus-nodes", "operations"]
 type: docs
+nav_next: /docs/advanced-solo-setup/jvm-debugger/
 ---
 
 ## Overview

--- a/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
@@ -25,7 +25,7 @@ Before proceeding, ensure you have:
   following methods:
   1. [**Quickstart**](/docs/simple-solo-setup/quickstart) - single command deployment using
      `solo one-shot single deploy`.
-  2. [**Manual Deployment**](/docs/advanced-solo-setup/advanced-network-deployments/manual-deployment) - step-by-step
+  2. [**Manual Deployment**](/docs/advanced-solo-setup/network-deployments/manual-deployment) - step-by-step
      deployment with full control over each component.
 
 - Set the required environment variables as described below:
@@ -53,7 +53,7 @@ appear in the `prepare` step.
       `hedera-node*.crt` and `hedera-node*.key` under `~/.solo/cache/keys/`.
 
     When adding a new node, Solo generates a fresh key pair and stores it
-    alongside the keys for existing nodes in the same directory. For more detail, see [Where are my keys stored?](/docs/faq/#5-where-are-my-keys-stored).
+    alongside the keys for existing nodes in the same directory. For more detail, see [Where are my keys stored?](/docs/faqs/#5-where-are-my-keys-stored).
 
 2. **Persistent Volume Claims (PVCs)**
 

--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
@@ -81,7 +81,7 @@ to the underlying Solo subcommands.
 | `blockNode` | `solo block node add` (when `ONE_SHOT_WITH_BLOCK_NODE=true`) |
 
 For the full list of supported CLI flags per section, see the
-[**Falcon Values File Reference**](/docs/advanced-solo-setup/advanced-network-deployments/falcon-flags-reference).
+[**Falcon Values File Reference**](/docs/advanced-solo-setup/network-deployments/falcon-flags-reference).
 
 ## Create a Falcon Values File
 
@@ -399,7 +399,7 @@ destroy unless you pass `--deployment` explicitly.
 Use Falcon deployment when you want a single, repeatable command backed by a
 versioned YAML file.
 
-Use [**Step-by-Step Manual Deployment**](/docs/advanced-solo-setup/advanced-network-deployments/manual-deployment)
+Use [**Step-by-Step Manual Deployment**](/docs/advanced-solo-setup/network-deployments/manual-deployment)
 when you need to pause between steps, inspect intermediate state, or debug a
 specific deployment phase in isolation.
 
@@ -410,7 +410,7 @@ In practice:
 
 ## Reference
 
-- [**Falcon Values File Reference**](/docs/advanced-solo-setup/advanced-network-deployments/falcon-flags-reference) - full list of supported CLI flags, types, and defaults for every section.
+- [**Falcon Values File Reference**](/docs/advanced-solo-setup/network-deployments/falcon-flags-reference) - full list of supported CLI flags, types, and defaults for every section.
 - [**Upstream example values file**](https://github.com/hiero-ledger/solo/tree/main/examples/one-shot-falcon) - working reference from the Solo repository.
 
 > **Tip:** If you are creating a values file for the first time, start from the

--- a/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
@@ -23,7 +23,7 @@ in isolation, or integrate Solo into a bespoke automation pipeline.
 
 Before proceeding, ensure you have completed the following:
 
-- [**System Readiness**](/docs/advanced-solo-setup/system-readiness) — your local environment
+- [**System Readiness**](/docs/simple-solo-setup/system-readiness) — your local environment
   meets all hardware and software requirements (Docker, kind, kubectl, helm, Solo).
 - [**Quickstart**](/docs/simple-solo-setup/quickstart) — you have a running Kind cluster and
   have run `solo init` at least once.

--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -8,6 +8,7 @@ description: >
 categories: ["Reference", "Advanced"]
 tags: ["advanced", "operator", "configuration", "cli"]
 type: docs
+nav_next: /docs/advanced-solo-setup/network-deployments/
 ---
 
 ## Overview

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -148,7 +148,7 @@ Use these endpoints:
 
     > **Warning:** Always use the `grep '^solo'` filter above — omitting it will delete **every** Kind cluster on your machine, including those unrelated to Solo.
 
-  After a full reset, you can redeploy by following the [Quickstart](../simple-solo-setup/quickstart) guide.
+  After a full reset, you can redeploy by following the [Quickstart](/docs/simple-solo-setup/quickstart) guide.
 
 - If you want to reset everything and start fresh immediately, run:
 

--- a/content/en/docs/troubleshooting.md
+++ b/content/en/docs/troubleshooting.md
@@ -423,4 +423,4 @@ When opening an issue, include:
 Join the community for discussions and help:
 
 - **Hedera Discord**: Look for the `#solo` channel
-- **Hiero Community**: <https://hiero.org/community>
+- **Contribute to Hiero**: <https://hiero.org/#contribute>

--- a/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
+++ b/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
@@ -44,7 +44,7 @@ Before proceeding, ensure you have completed the following:
 
 > **Note:** If you deployed your network using
 > [one-shot](/docs/simple-solo-setup/quickstart),
-> [Falcon](/docs/advanced-solo-setup/advanced-network-deployments/falcon-deployment),
+> [Falcon](/docs/advanced-solo-setup/network-deployments/falcon-deployment),
 > or the [Task Tool](/docs/advanced-solo-setup/customizing-solo-with-tasks),
 > Mirror Node is already running -
 > skip to [Step 2: Access the Mirror Node Explorer](#step-2-access-the-mirror-node-explorer).
@@ -136,7 +136,7 @@ solo ledger account create --deployment solo-deployment --hbar-amount 100
 Open the Explorer at `http://localhost:8080` to see the new accounts and their
 transactions recorded by the Mirror Node.
 
-You can also use the [Hiero JavaScript SDK](/docs/using-solo/javascript-sdk)
+You can also use the [Hiero JavaScript SDK](/docs/using-solo/using-solo-with-javascript-sdk)
 to create a topic, submit a message, and subscribe to it.
 
 ---

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -406,7 +406,7 @@ task destroy
 ```
 
 This is useful for CI pipelines. See the
-[Solo deployment with Hardhat Example](/examples/hardhat-with-solo/) for full
+[Solo deployment with Hardhat Example](https://github.com/hiero-ledger/solo/tree/main/examples/hardhat-with-solo) for full
 details.
 
 ---
@@ -427,6 +427,6 @@ details.
 
 ## Further Reading
 
-- [Solo deployment with Hardhat Example](/examples/hardhat-with-solo/).
+- [Solo deployment with Hardhat Example](https://github.com/hiero-ledger/solo/tree/main/examples/hardhat-with-solo).
 - [Configuring Hardhat with Hiero Local Node](https://docs.hedera.com/hedera/tutorials/smart-contracts/configuring-hardhat-with-hiero-local-node-a-step-by-step-guide) - the Hedera tutorial this guide is modelled on.
-- [Retrieving Logs](/docs/jvm-debugger/) - for debugging network-level issues.
+- [Retrieving Logs](/docs/advanced-solo-setup/jvm-debugger/) - for debugging network-level issues.

--- a/content/en/docs/using-solo/using-solo-with-javascript-sdk.md
+++ b/content/en/docs/using-solo/using-solo-with-javascript-sdk.md
@@ -30,7 +30,7 @@ Before proceeding, ensure you have completed the following:
     | Requirement | Version | Purpose |
     | --- | --- | --- |
     | [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Latest | Runs the Solo cluster containers |
-    | [Solo](/onboarding/system-readiness) | Latest | Deploys and manages the local network |
+    | [Solo](/docs/simple-solo-setup/system-readiness) | Latest | Deploys and manages the local network |
     | [Node.js](https://nodejs.org/) | v18 or higher | Runs the SDK examples |
     | [Taskfile](https://taskfile.dev/installation/) | Latest | Runs convenience scripts in the Solo repo |
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -169,7 +169,7 @@ params:
   url_latest_version: https://solo.hiero.org/
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-  github_repo: https://github.com/hiero-ledger/solo
+  github_repo: https://github.com/hiero-ledger/solo-docs
 
   # An optional link to a related project repo. For example, the sibling repository where your product code lives.
   github_project_repo: https://github.com/hiero-ledger/solo

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,6 +1,7 @@
+{{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
-	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+  {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
@@ -9,9 +10,10 @@
 	</header>
 	{{ .Render "_td-content-after-header" -}}
 	{{ .Content }}
+	{{ partial "section-index.html" . -}}
 	{{/* Allow explicit cross-section prev/next overrides via front matter */}}
-	{{ $previous := .NextInSection -}}
-	{{ $next := .PrevInSection -}}
+	{{ $previous := false -}}
+	{{ $next := false -}}
 	{{ with .Params.nav_prev }}{{ $previous = site.GetPage . }}{{ end -}}
 	{{ with .Params.nav_next }}{{ $next = site.GetPage . }}{{ end -}}
 	{{ if or $previous $next -}}
@@ -23,12 +25,12 @@
 				<span class="td-docs-page-nav__title">{{ $previous.Title }}</span>
 			</a>
 			{{ end -}}
-				{{ if $next -}}
+			{{ if $next -}}
 			<a class="td-docs-page-nav__link td-docs-page-nav__link--next" href="{{ $next.RelPermalink }}" rel="next" aria-label="{{ T "ui_pager_next" }} - {{ $next.Title }}">
 				<span class="td-docs-page-nav__label">{{ T "ui_pager_next" }} &rarr;</span>
 				<span class="td-docs-page-nav__title">{{ $next.Title }}</span>
 			</a>
-				{{ end -}}
+			{{ end -}}
 		</div>
 	</nav>
 	{{ end -}}
@@ -37,6 +39,6 @@
 		<br />
 		{{- partial "disqus-comment.html" . -}}
 	{{ end -}}
-	{{ partial "page-meta-lastmod.html" . }}
+	{{ partial "page-meta-lastmod.html" . -}}
 </div>
-{{/**/ -}}
+{{ end -}}


### PR DESCRIPTION
**Description**:
This PR fixes documentation link integrity issues and corrects broken prev/next navigation flow in Advanced Solo Setup pages. It is needed to prevent dead-end docs navigation and eliminate broken internal/external references surfaced by link checks.

- Fix broken internal doc links across advanced setup, FAQs, and usage guides
- Update external/community references and source repository metadata to valid targets
- Add explicit cross-section pager overrides via nav_prev/nav_next front matter
- Update docs templates to honor pager overrides for both single pages and section index pages
- Wire boundary pages in Advanced Solo Setup so reader flow is consistent end-to-end

**Related issue(s)**:

Fixes #80 

**Notes for reviewer**:

- Branch includes two logical commits:
  - link integrity fixes (internal + external)
  - pager navigation fixes across section boundaries
- Validation performed:
  - local Hugo build succeeded
  - pager sequence verified on affected Advanced Solo Setup pages (including section landing pages)
  - external link audit rerun on live site context; remaining failures were environment/rate-limit related, while addressed broken targets in this branch were corrected

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
