### PR TITLE
docs(feedback): clarify command-line flags section, fix overview typo, update Solo CI workflow versions and add cleanup steps

### DIFF
--- a/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
+++ b/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
@@ -288,7 +288,8 @@ task solo:block:add
 
 Low-level tasks for managing clusters and network infrastructure:
 
-| Task                        | Description                                                |\n| --------------------------- | ---------------------------------------------------------- |
+| Task                        | Description                                                |
+| --------------------------- | ---------------------------------------------------------- |
 | `cluster:create`            | Create a Kind (Kubernetes in Docker) cluster               |
 | `cluster:destroy`           | Delete the Kind cluster                                    |
 | `solo:cluster:setup`        | Setup cluster infrastructure and prerequisites             |

--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
@@ -16,9 +16,7 @@ One-shot Falcon deployment is Solo's YAML-driven one-shot workflow. It uses the 
 deployment pipeline as `solo one-shot single deploy`, but lets you inject
 component-specific flags through a single values file.
 
-One-shot use Falcon deployment when you need a repeatable advanced setup, want to check a
-complete deployment into source control, or need to customise component flags
-without running every Solo command manually.
+Use One-shot Falcon deployment when you need a repeatable advanced setup, want to check a complete deployment into source control, or need to customise component flags without running every Solo command manually.
 
 Falcon is especially useful for:
 
@@ -36,19 +34,8 @@ Falcon is especially useful for:
 
 Before proceeding, ensure you have completed the following:
 
-- [**System Readiness**](/docs/simple-solo-setup/system-readiness) -your local environment
-  meets the hardware and software requirements for Solo, Kubernetes, Docker,
-  Kind, kubectl, and Helm.
-- [**Quickstart**](/docs/simple-solo-setup/quickstart) -you are already familiar with the
-  standard one-shot deployment workflow.
-- Set your environment variables if you have not already done so:
-
-  ```bash
-  export SOLO_CLUSTER_NAME=solo
-  export SOLO_NAMESPACE=solo
-  export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
-  export SOLO_DEPLOYMENT=solo-deployment
-  ```
+- [**System Readiness**](/docs/simple-solo-setup/system-readiness) - your local environment meets the hardware and software requirements for Solo, Kubernetes, Docker, Kind, kubectl, and Helm.
+- [**Quickstart**](/docs/simple-solo-setup/quickstart) -you are already familiar with the standard one-shot deployment workflow.
 
 ## How Falcon Works
 
@@ -64,8 +51,7 @@ sequence used by its one-shot workflows:
 7. Optionally, deploy mirror node, explorer, and relay in parallel for faster
    startup.
 8. Create predefined test accounts.
-9. Write deployment notes, versions, port-forward details, and account data to a
-   local output directory.
+9. Write deployment notes, versions, port-forward details, and account data to a local output directory.
 
 The difference is that Falcon reads a YAML file and maps its top-level sections
 to the underlying Solo subcommands.
@@ -131,14 +117,14 @@ solo one-shot falcon deploy --values-file falcon-values.yaml
 Solo creates a one-shot deployment, applies the values from the YAML file to the
 appropriate subcommands, and then deploys the full environment.
 
-### What Falcon Does Not Read from the File
+### Command-Line Flags (Not in YAML File)
 
-Some Falcon settings are controlled directly by the top-level command flags,
-not by section entries in the values file:
+The following flags are passed on the command line and cannot be set in the YAML file:
+- `--deployment`, `--namespace`, `--cluster-ref`, `--num-consensus-nodes`
+
+Note: `--values-file` specifies which YAML file to load.
 
 - `--values-file` selects the YAML file to load.
-- `--deploy-mirror-node`, `--deploy-explorer`, and `--deploy-relay` control
-  whether those optional components are deployed at all.
 - `--deployment`, `--namespace`, `--cluster-ref`, and `--num-consensus-nodes`
   are top-level one-shot inputs.
 
@@ -214,36 +200,6 @@ want to manage each step manually.
 > [**System Readiness**](/docs/simple-solo-setup/system-readiness), and increase Docker
 > memory and CPU allocation before deploying.
 
-## (Optional) Component Toggles
-
-Falcon can skip optional components at the command line without requiring a
-second YAML file.
-
-For example, to deploy only the consensus network and mirror node:
-
-```bash
-solo one-shot falcon deploy \
-  --values-file falcon-values.yaml \
-  --deploy-explorer=false \
-  --deploy-relay=false
-```
-
-Available toggles and their defaults:
-
-| Flag | Default | Description |
-| ---- | ------- | ----------- |
-| `--deploy-mirror-node` | `true` | Include the mirror node in the deployment. |
-| `--deploy-explorer` | `true` | Include the explorer in the deployment. |
-| `--deploy-relay` | `true` | Include the JSON RPC relay in the deployment. |
-
-> **Important**: The explorer and relay both depend on the mirror node. Setting `--deploy-mirror-node=false` while keeping `--deploy-explorer=true` or `--deploy-relay=true` is not a supported configuration and will result in a failed deployment.
-
-This is useful when you want to:
-
-- Reduce resource usage in CI jobs.
-- Isolate one component during testing.
-- Reuse the same YAML file across multiple deployment profiles.
-
 ## Common Falcon Customisations
 
 Because each YAML section maps directly to the corresponding Solo subcommand,
@@ -283,7 +239,7 @@ Falcon can also include block node configuration.
 > **Note:** Block node workflows are advanced and require higher resource
 > allocation and version compatibility across consensus node, block node, and
 > related components.
->Docker memory must be set to at least 16 GB before deploying with block node enabled.
+> Docker memory must be set to at least 16 GB before deploying with block node enabled.
 >
 > Block node support also requires the
 > `ONE_SHOT_WITH_BLOCK_NODE=true` environment variable to be set before
@@ -327,24 +283,6 @@ relayNode:
 Use block node settings only when your target Solo and component versions are
 known to be compatible.
 
-## Rollback and Failure Behaviour
-
-Falcon deployment enables automatic rollback by default.
-
-If deployment fails after resources have already been created, Solo attempts to
-destroy the one-shot deployment automatically and clean up the namespace.
-
-If you want to preserve the failed deployment for debugging, disable rollback:
-
-```bash
-solo one-shot falcon deploy \
-  --values-file falcon-values.yaml \
-  --no-rollback
-```
-
-Use `--no-rollback` only when you explicitly want to inspect partial resources,
-logs, or Kubernetes objects after a failed run.
-
 ## Deployment Output
 
 After a successful Falcon deployment, Solo writes deployment metadata to
@@ -363,18 +301,9 @@ This directory typically contains:
 This makes Falcon especially useful for automation, because the deployment
 artifacts are written to a predictable path after each run.
 
-To inspect the latest one-shot deployment metadata later, run:
+To inspect deployment output, check the `~/.solo/one-shot-<deployment>/` directory directly.
 
-```bash
-solo one-shot show deployment
-```
-
-If port-forwards are interrupted after deployment - for example after a system
-restart or network disruption - restore them without redeploying:
-
-```bash
-solo deployment refresh port-forwards
-```
+If port-forwards are interrupted after deployment, restore them by rerunning the component commands (such as `solo consensus node start`, `solo mirror node add`, etc.)
 
 ## Destroy a Falcon Deployment
 

--- a/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
+++ b/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
@@ -71,12 +71,14 @@ Install Kind to create and manage a local Kubernetes cluster in your workflow.
       uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
       with:
         install_only: true
-        node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-        version: v0.26.0
-        kubectl_version: v1.31.4
+        node_image: kindest/node:v1.32.2@sha256:3966f21e12b760f6585bde7140cae5e8cdc0e52b37a6f90ce39834b6e72e3f49
+        version: v0.29.0
+        kubectl_version: v1.32.2
         verbosity: 3
         wait: 120s
   ```
+  > **Important:** Kind version must be **v0.29.0 or later** and  Kubernetes version must be **v1.32.2 or late**r. Solo enforces this 
+  > minimum version at runtime. Installing an older version will cause deployment failures.
 
 ## Step 2: Install Node.js
 
@@ -97,7 +99,7 @@ breaking changes from newer releases and cause unexpected workflow failures.
     - name: Install Solo CLI
       run: |
         set -euo pipefail
-        npm install -g @hiero-ledger/solo@0.68.0
+        npm install -g @hiero-ledger/solo@<version>
         solo --version
         kind --version
   ```
@@ -124,50 +126,108 @@ a fully functional local Hiero network, including:
         solo one-shot single deploy | tee solo-deploy.log
   ```
 
+## Cleanup
+
+After the workflow completes, destroy the Solo deployment and delete the Kind
+cluster to avoid leaving resources behind.
+
+  ```yaml
+    - name: Destroy Solo deployment
+      env:
+        SOLO_DEPLOYMENT: solo-deployment
+      run: |
+        set -euo pipefail
+        solo one-shot single destroy --deployment "${SOLO_DEPLOYMENT}"
+  ```
+
+  ```yaml
+    - name: Delete Kind cluster
+      env:
+        SOLO_CLUSTER_NAME: solo
+      run: |
+        set -euo pipefail
+        kind delete cluster -n "${SOLO_CLUSTER_NAME}"
+  ```
+
 ## Complete Example Workflow
 
 The following is the full workflow combining all steps above. Copy this into your
 .github/workflows/ directory as a starting point.
 
 ```yaml
+name: Solo CI Example
 
-  - name: Check Docker Resources
-    run: |
-      read cpus mem <<<"$(docker info --format '{{.NCPU}} {{.MemTotal}}')"
-      mem_gb=$(awk -v m="$mem" 'BEGIN{printf "%.1f", m/1000000000}')
-      echo "CPU cores: $cpus"
-      echo "Memory: ${mem_gb} GB"
-      
-  - name: Setup Kind
-    uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
-    with:
-      install_only: true
-      node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
-      version: v0.26.0
-      kubectl_version: v1.31.4
-      verbosity: 3
-      wait: 120s
+on:
+  workflow_dispatch:
+    inputs:
+      solo_version:
+        description: 'Solo CLI version to install'
+        required: false
+        default: '0.69.0'
+      kind_version:
+        description: 'Kind version to install (minimum v0.29.0)'
+        required: false
+        default: 'v0.29.0'
+      kubectl_version:
+        description: 'kubectl version to install (minimum v1.32.2)'
+        required: false
+        default: 'v1.32.2'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Docker Resources
+        run: |
+          read cpus mem <<<"$(docker info --format '{{.NCPU}} {{.MemTotal}}')"
+          mem_gb=$(awk -v m="$mem" 'BEGIN{printf "%.1f", m/1000000000}')
+          echo "CPU cores: $cpus"
+          echo "Memory: ${mem_gb} GB"
+          
+      - name: Setup Kind
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
+        with:
+          install_only: true
+          node_image: kindest/node:v1.32.2@sha256:3966f21e12b760f6585bde7140cae5e8cdc0e52b37a6f90ce39834b6e72e3f49
+          version: v0.29.0
+          kubectl_version: v1.32.2
+          verbosity: 3
+          wait: 120s
          
-  - name: Set up Node.js
-    uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-    with:
-      node-version: 22.12.0
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22.12.0
       
-  - name: Install Solo CLI
-    run: |
-      set -euo pipefail
-      npm install -g @hiero-ledger/solo@0.68.0
-      solo --version
-      kind --version
+      - name: Install Solo CLI
+        run: |
+          set -euo pipefail
+          npm install -g @hiero-ledger/solo@<version>
+          solo --version
+          kind --version
       
-  - name: Deploy Solo
-    env:
-      SOLO_CLUSTER_NAME: solo
-      SOLO_NAMESPACE: solo
-      SOLO_CLUSTER_SETUP_NAMESPACE: solo-cluster
-      SOLO_DEPLOYMENT: solo-deployment
-    run: |
-      set -euo pipefail
-      kind create cluster -n "${SOLO_CLUSTER_NAME}"
-      solo one-shot single deploy | tee solo-deploy.log
+      - name: Deploy Solo
+        env:
+          SOLO_CLUSTER_NAME: solo
+          SOLO_NAMESPACE: solo
+          SOLO_CLUSTER_SETUP_NAMESPACE: solo-cluster
+          SOLO_DEPLOYMENT: solo-deployment
+        run: |
+          set -euo pipefail
+          kind create cluster -n "${SOLO_CLUSTER_NAME}"
+          solo one-shot single deploy | tee solo-deploy.log
+
+      - name: Destroy Solo deployment
+        env:
+          SOLO_DEPLOYMENT: solo-deployment
+        run: |
+          set -euo pipefail
+          solo one-shot single destroy --deployment "${SOLO_DEPLOYMENT}"
+
+      - name: Delete Kind cluster
+        env:
+          SOLO_CLUSTER_NAME: solo
+        run: |
+          set -euo pipefail
+          kind delete cluster -n "${SOLO_CLUSTER_NAME}"
 ```


### PR DESCRIPTION
**Description**:

1. Refine the falcon deployment documentation to improve clarity and accuracy by removing content about unreleased flags and fixing minor issues.
2. Update the Solo CI workflow documentation to align with current Solo and Kind compatibility requirements, and add explicit cleanup steps for CI runs.
    - Update Kind node image and kubectl version to v1.32.2
    - Set Kind minimum version to v0.29.0
    - Update Solo CLI workflow defaults to 0.69.0
    - Add cleanup commands for solo one-shot single destroy and kind delete cluster


**Related issue(s)**:

Fixes #82 

**Notes for reviewer**:
No additional notes needed - changes are purely documentation improvements.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)