### PR TITLE
fix(docs): correct environment variables reference accuracy

### DIFF
--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -38,13 +38,12 @@ commands.
 
 | Environment Variable | Description | Default Value
 | --- | --- | ---
-| `DEFAULT_START_ID_NUMBER` | First node account ID of the Solo test network | `0.0.3`
+| `DEFAULT_START_ID_NUMBER` | Raw node ID number for the first consensus node. The first node account ID is resolved as `0.0.<DEFAULT_START_ID_NUMBER>` | `3`
 | `SOLO_NODE_INTERNAL_GOSSIP_PORT` | Internal gossip port used by the Hiero network | `50111`
 | `SOLO_NODE_EXTERNAL_GOSSIP_PORT` | External gossip port used by the Hiero network | `50111`
 | `SOLO_NODE_DEFAULT_STAKE_AMOUNT` | Default stake amount for a node | `500`
 | `GRPC_PORT` | gRPC port used for local node communication | `50211`
 | `LOCAL_NODE_START_PORT` | Local node start port for the Solo network | `30212`
-| `SOLO_CHAIN_ID` | Chain ID of the Solo network | `298`
 
 ---
 
@@ -71,7 +70,6 @@ commands.
 | `NODE_CLIENT_MAX_BACKOFF` | Maximum wait time between retries, in milliseconds | `1000`
 | `NODE_CLIENT_REQUEST_TIMEOUT` | Time a transaction or query retries on a "busy" network response, in milliseconds | `600000`
 | `NODE_CLIENT_MAX_ATTEMPTS` | Maximum number of attempts for node client operations | `600`
-| `NODE_CLIENT_PING_INTERVAL` | Interval between node health pings, in milliseconds | `30000`
 | `NODE_CLIENT_SDK_PING_MAX_RETRIES` | Maximum number of retries for node health pings | `5`
 | `NODE_CLIENT_SDK_PING_RETRY_INTERVAL` | Interval between node health ping retries, in milliseconds | `10000`
 | `NODE_COPY_CONCURRENT` | Number of concurrent threads used when copying files to a node | `4`
@@ -101,6 +99,8 @@ commands.
 
 | Environment Variable | Description | Default Value
 | --- | --- | ---
+| `BLOCK_NODE_PODS_RUNNING_MAX_ATTEMPTS` | Maximum number of attempts to check if block node pods are running | `900`
+| `BLOCK_NODE_PODS_RUNNING_DELAY` | Interval between block node pod running checks, in milliseconds | `1000`
 | `BLOCK_NODE_ACTIVE_MAX_ATTEMPTS` | Maximum number of attempts to check if block nodes are active | `100`
 | `BLOCK_NODE_ACTIVE_DELAY` | Interval between block node active checks, in milliseconds | `60`
 | `BLOCK_NODE_ACTIVE_TIMEOUT` | Maximum wait time for block nodes to become active, in milliseconds | `60`
@@ -140,18 +140,18 @@ commands.
 
 ## Component Versions
 
-| Environment Variable | Description | Default Value
-| --- | --- | ---
-| `CONSENSUS_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-consensus-node/releases) of the Consensus Node to use | `v0.65.1`
-| `BLOCK_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-block-node/releases) of the Block Node to use | `v0.18.0`
-| `MIRROR_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-mirror-node/releases) of the Mirror Node to use | `v0.138.0`
-| `EXPLORER_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-mirror-node-explorer/releases) of the Explorer to use | `v25.1.1`
-| `RELAY_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-json-rpc-relay/releases) of the JSON-RPC Relay to use | `v0.70.0`
-| `INGRESS_CONTROLLER_VERSION` | [Release version](https://haproxy-ingress.github.io/) of the HAProxy Ingress Controller to use | `v0.14.5`
-| `SOLO_CHART_VERSION` | Release version of the Solo Helm charts to use | `v0.56.0`
-| `MINIO_OPERATOR_VERSION` | Release version of the MinIO Operator to use | `7.1.1`
-| `PROMETHEUS_STACK_VERSION` | Release version of the Prometheus Stack to use | `52.0.1`
-| `GRAFANA_AGENT_VERSION` | Release version of the Grafana Agent to use | `0.27.1`
+| Environment Variable | Description
+| --- | ---
+| `CONSENSUS_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-consensus-node/releases) of the Consensus Node to use
+| `BLOCK_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-block-node/releases) of the Block Node to use
+| `MIRROR_NODE_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-mirror-node/releases) of the Mirror Node to use
+| `EXPLORER_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-mirror-node-explorer/releases) of the Explorer to use
+| `RELAY_VERSION` | [Release version](https://github.com/hiero-ledger/hiero-json-rpc-relay/releases) of the JSON-RPC Relay to use
+| `INGRESS_CONTROLLER_VERSION` | [Release version](https://haproxy-ingress.github.io/) of the HAProxy Ingress Controller to use
+| `SOLO_CHART_VERSION` | Release version of the Solo Helm charts to use
+| `MINIO_OPERATOR_VERSION` | Release version of the MinIO Operator to use
+| `PROMETHEUS_STACK_VERSION` | Release version of the Prometheus Stack to use
+| `GRAFANA_AGENT_VERSION` | Release version of the Grafana Agent to use
 
 ---
 


### PR DESCRIPTION
**Description**:
Fix inaccuracies in the environment variables reference identified during an accuracy audit against constants.ts and version.ts.

Fix DEFAULT_START_ID_NUMBER default from 0.0.3 to 3 and clarify it is a raw integer, not an account ID
Remove NODE_CLIENT_PING_INTERVAL which does not exist in source
Add missing BLOCK_NODE_PODS_RUNNING_MAX_ATTEMPTS and BLOCK_NODE_PODS_RUNNING_DELAY to the Block Node section
Remove Default Value column from Component Versions section to avoid version drift on each Solo release
Remove duplicate SOLO_CHAIN_ID entry from the Network and Node Identity section

Fixes #82 

**Notes for reviewer**:


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
