### PR TITLE
fix(docs): fix consensus node operations commands, links, version, and indentation

### DIFF
--- a/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/consensus-node-operations.md
@@ -32,11 +32,11 @@ Before proceeding, ensure you have:
 - Set the required environment variables as described below:
 
   ```bash
-    export SOLO_CLUSTER_NAME=solo
-    export SOLO_NAMESPACE=solo
-    export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
-    export SOLO_DEPLOYMENT=solo-deployment
-    ```
+  export SOLO_CLUSTER_NAME=solo
+  export SOLO_NAMESPACE=solo
+  export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
+  export SOLO_DEPLOYMENT=solo-deployment
+  ```
 
 ## Key and Storage Concepts
 
@@ -89,15 +89,15 @@ This process involves three stages: preparing the node's keys and configuration,
 Generate the new node's gossip and TLS keys, create its persistent volumes, and stage its configuration into an output directory:
 
 ```bash
-    solo consensus dev-node-add prepare \
-    --gossip-keys true \
-    --tls-keys true \
-    --deployment "${SOLO_DEPLOYMENT}" \
-    --pvcs true \
-    --admin-key <admin-key> \
-    --node-alias node2 \
-    --output-dir context
-  ```
+solo consensus dev-node-add prepare \
+  --gossip-keys true \
+  --tls-keys true \
+  --deployment "${SOLO_DEPLOYMENT}" \
+  --pvcs true \
+  --admin-key <admin-key> \
+  --node-alias node2 \
+  --output-dir context
+```
 
 | Flag | Description |
 | --- | --- |
@@ -113,22 +113,22 @@ Generate the new node's gossip and TLS keys, create its persistent volumes, and 
 Submit the on-chain transaction to register the new node with the network:
 
 ```bash
-  solo consensus dev-node-add submit-transaction \
+solo consensus dev-node-add submit-transactions \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
 ### Step 3: Execute the node addition
 
 Apply the node addition and bring the new node online:
 
 ```bash
-  solo consensus dev-node-add execute \
+solo consensus dev-node-add execute \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
-> Note: For a complete walkthrough with expected outputs, see the Node Create Transaction example.
+> Note: For a complete walkthrough with expected outputs, see the [Node Create Transaction example](https://github.com/hiero-ledger/solo/tree/main/examples/node-create-transaction).
 
 ## Updating a Node
 
@@ -138,18 +138,19 @@ You can update an existing consensus node - for example, to upgrade its software
 
 Stage the updated configuration and any new software version for the target node:
 
-  ```bash
-    solo consensus dev-node-update prepare \
-    --deployment "${SOLO_DEPLOYMENT}" \
-    --node-alias node1 \
-    --release-tag v0.61.0 \
-    --output-dir context
-  ```
+```bash
+solo consensus dev-node-update prepare \
+  --deployment "${SOLO_DEPLOYMENT}" \
+  --node-alias node1 \
+  --release-tag v0.66.0 \
+  --output-dir context
+```
 
 | Flag | Description |
 | --- | --- |
 | --node-alias | Alias of the node to update (e.g., node1). |
 | --release-tag | The consensus node software version to update to. |
+| --new-admin-key | (Optional) New admin key for the node's Hedera account. Omit to keep the existing admin key. |
 | --output-dir | Directory where prepared context files are saved for use in subsequent steps. |
 
 ### Step 2: Submit the update transaction
@@ -157,22 +158,22 @@ Stage the updated configuration and any new software version for the target node
 Submit the on-chain transaction to register the node update with the network:
 
 ```bash
-  solo consensus dev-node-update submit-transaction \
+solo consensus dev-node-update submit-transactions \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
 ### Step 3: Execute the update
 
 Apply the update and restart the node with the new configuration:
 
 ```bash
-  solo consensus dev-node-update execute \
+solo consensus dev-node-update execute \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
-> Note: For a complete walkthrough with expected outputs, see the Node Update Transaction example.
+> Note: For a complete walkthrough with expected outputs, see the [Node Update Transaction example](https://github.com/hiero-ledger/solo/tree/main/examples/node-update-transaction).
 
 ## Removing a Node from a Network
 
@@ -186,11 +187,11 @@ You can dynamically remove a consensus node from a running network without takin
 Stage the deletion context for the target node:
 
 ```bash
-  solo consensus dev-node-delete prepare \
+solo consensus dev-node-delete prepare \
   --deployment "${SOLO_DEPLOYMENT}" \
   --node-alias node2 \
   --output-dir context
-  ```
+```
 
 | Flag | Description |
 | --- | --- |
@@ -202,19 +203,19 @@ Stage the deletion context for the target node:
 Submit the on-chain transaction to deregister the node from the network:
 
 ```bash
-  solo consensus dev-node-delete submit-transaction \
+solo consensus dev-node-delete submit-transactions \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
 ### Step 3: Execute the deletion
 
 Remove the node and clean up its associated resources:
 
 ```bash
-  solo consensus dev-node-delete execute \
+solo consensus dev-node-delete execute \
   --deployment "${SOLO_DEPLOYMENT}" \
   --input-dir context
-  ```
+```
 
-> Note: For a complete walkthrough with expected outputs, see the Node Delete Transaction example.
+> Note: For a complete walkthrough with expected outputs, see the [Node Delete Transaction example](https://github.com/hiero-ledger/solo/tree/main/examples/node-delete-transaction).


### PR DESCRIPTION
**Description**:

- Fix `submit-transaction` → `submit-transactions` (plural) in all three
  node operation workflows (add, update, delete) - the singular form produces
  a "command not found" error at runtime.
- Add links to the Node Create, Update, and Delete Transaction examples on
  GitHub, replacing the unlinked plain-text references.
- Update stale `--release-tag v0.61.0` to `v0.66.0` to match the version
  used throughout the manual deployment guide.
- Add `--new-admin-key` as an optional flag in the update prepare flag table
  (sourced from `consensus-command-definition.ts`) - omitted from the command
  snippet as it defaults to empty and is only needed when explicitly rotating
  the admin key.
- Normalise code block indentation throughout - no leading spaces on commands,
  flags consistently indented 2 spaces, closing fences at column 0.

**Related issue(s)**:

Fixes #82 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
