### PR TITLE
docs: add performance-tests-local page under advanced solo setup

### DIFF
--- a/content/en/docs/advanced-solo-setup/performance-tests-local/_index.md
+++ b/content/en/docs/advanced-solo-setup/performance-tests-local/_index.md
@@ -1,0 +1,80 @@
+---
+title: 'Run Performance Tests Locally'
+weight: 6
+description: >
+  Run Solo E2E performance tests locally, including setup, execution, optional
+  local build path configuration, and branch workflow triggering.
+categories: ['Advanced', 'Testing']
+tags: ['advanced', 'performance', 'testing', 'ci-cd']
+type: docs
+nav_prev: /docs/advanced-solo-setup/solo-ci-workflow/
+nav_next: /docs/advanced-solo-setup/cli/
+---
+
+## Overview
+
+This guide shows how to run the Solo E2E performance test on a local machine.
+
+## Prerequisites
+
+- `task`, `node`, `npm`, `kubectl`, and `kind` installed
+- Docker running
+- Solo dependencies installed (`npm ci`)
+
+## Run the Performance Test
+
+From the repository root:
+
+```bash
+task test-setup
+task test-e2e-performance
+```
+
+The test uses one-shot single deploy/destroy flow and then runs rapid-fire load
+tests.
+
+## Optional: Use a Local Consensus Node Build
+
+If you already have a local consensus node build, set `SOLO_LOCAL_BUILD_PATH` so
+commands that consume `--local-build-path` can use it by default:
+
+```bash
+export SOLO_LOCAL_BUILD_PATH="/absolute/path/to/hiero-consensus-node/hedera-node/data"
+task test-setup
+task test-e2e-performance
+```
+
+## Optional: Shorten Test Duration
+
+You can shorten load-test duration while iterating:
+
+```bash
+export ONE_SHOT_METRICS_TEST_DURATION_IN_MINUTES=2
+task test-e2e-performance
+```
+
+## Run the GitHub Performance Workflow for a Branch
+
+You can run the repository performance workflow against any pushed Solo branch.
+
+### Option 1: Using `gh` CLI
+
+```bash
+export SOLO_BRANCH="<your-branch-name>"
+gh workflow run "Performance Test Solo Deployment" --ref "${SOLO_BRANCH}" --repo hiero-ledger/solo
+```
+
+Watch the latest run for that branch:
+
+```bash
+RUN_ID=$(gh run list --workflow "Performance Test Solo Deployment" --branch "${SOLO_BRANCH}" --limit 1 --json databaseId -q '.[0].databaseId')
+gh run watch "${RUN_ID}" --repo hiero-ledger/solo
+```
+
+### Option 2: Using GitHub Web UI
+
+1. Open
+   `https://github.com/hiero-ledger/solo/actions/workflows/flow-performance-test.yaml`.
+2. Click `Run workflow`.
+3. Select your branch in the branch dropdown.
+4. Click `Run workflow` to start the run.

--- a/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
+++ b/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
@@ -8,6 +8,7 @@ description: >
 categories: ["Advanced"]
 tags: ["advanced", "developer", "ci-cd", "testing"]
 type: docs
+nav_next: /docs/advanced-solo-setup/performance-tests-local/
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- add new page: `content/en/docs/advanced-solo-setup/performance-tests-local/_index.md`
- sync content from solo repo performance tests documentation
- wire navigation by setting `nav_next` in `solo-ci-workflow.md` to the new page

## Notes
- page is placed under advanced setup with weight `6` so it appears in section ordering
