### PR TITLE
docs(ports): update service endpoints for Solo 0.63+ and document legacy ports

### DIFF
--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -91,25 +91,25 @@ solo one-shot single deploy
 
 ### How do I access services after deployment?
 
-After running `solo one-shot single deploy`, the following services are available on localhost:
+After running `solo one-shot single deploy`, the following services are available on localhost. The ports below are the **defaults for Solo 0.63 and later**:
 
-| Service               | Endpoint                | Description                                      |
-| --------------------- | ----------------------- | ------------------------------------------------ |
-| Explorer UI           | `http://localhost:8080` | Web UI for inspecting accounts and transactions. |
-| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for submitting transactions.       |
-| Mirror node REST API  | `http://localhost:5551` | REST API for querying historical data.           |
-| JSON RPC relay        | `localhost:7546`        | Ethereum-compatible JSON RPC endpoint.           |
+| Service               | Endpoint                 | Description                                      |
+| --------------------- | ------------------------ | ------------------------------------------------ |
+| Explorer UI           | `http://localhost:38080` | Web UI for inspecting accounts and transactions. |
+| Consensus node (gRPC) | `localhost:35211`        | gRPC endpoint for submitting transactions.       |
+| Mirror node REST API  | `http://localhost:38081` | REST API for querying historical data.           |
+| JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint.           |
 
-- Open `http://localhost:8080` in your browser to start exploring your local network.
+- Open `http://localhost:38080` in your browser to start exploring your local network.
 
 - To verify these services are reachable, you can run a quick health check:
 
     ```bash
     # Mirror node REST API
-    curl -s "http://localhost:5551/api/v1/transactions?limit=1"
+    curl -s "http://localhost:38081/api/v1/transactions?limit=1"
     
     # JSON RPC relay
-    curl -s -X POST http://localhost:7546 \
+    curl -s -X POST http://localhost:37546 \
       -H "Content-Type: application/json" \
       --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
     ```
@@ -122,13 +122,26 @@ After running `solo one-shot single deploy`, the following services are availabl
 
     All Solo-related pods should be in a `Running` or `Completed` state before the endpoints become available.
 
+> **Note:** These are Solo's default port targets. If a port is already in use on your machine, Solo automatically selects the next available port. The actual ports used are printed at the end of deployment and saved to `~/.solo/one-shot-<deployment-name>/forwards`. See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for details.
+
+**Solo 0.62 and earlier** used different default ports:
+
+| Service               | Endpoint                | Description                                      |
+| --------------------- | ----------------------- | ------------------------------------------------ |
+| Explorer UI           | `http://localhost:8080` | Web UI for inspecting accounts and transactions. |
+| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for submitting transactions.       |
+| Mirror node REST API  | `http://localhost:8081` | REST API for querying historical data (via mirror-ingress). |
+| JSON RPC relay        | `http://localhost:7546` | Ethereum-compatible JSON RPC endpoint.           |
+
+> **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible only via manual `kubectl port-forward`, and is being phased out. The ingress-based port (`8081` for older Solo, `38081` for Solo 0.63+) is the recommended entry point.
+
 ### How do I connect my application to the local network?
 
-Use these endpoints:
+Use these endpoints (Solo 0.63 and later):
 
-- **gRPC (Hedera SDK)**: `localhost:50211`, Node ID: `0.0.3`
-- **JSON RPC (Ethereum tools)**: `http://localhost:7546`
-- **Mirror Node REST**: `http://localhost:5551/api/v1/`
+- **gRPC (Hedera SDK)**: `localhost:35211`, Node ID: `0.0.3`
+- **JSON RPC (Ethereum tools)**: `http://localhost:37546`
+- **Mirror Node REST**: `http://localhost:38081/api/v1/`
 
 ### What should I do if `solo one-shot single destroy` fails or my Solo state is corrupted?
 

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -141,7 +141,7 @@ After running `solo one-shot single deploy`, the following services are availabl
 
     All Solo-related pods should be in a `Running` or `Completed` state before the endpoints become available.
 
-> **Note:** These are Solo's default port targets. If a port is already in use on your machine, Solo automatically selects the next available port. The actual ports used are printed at the end of deployment and saved to `~/.solo/one-shot-<deployment-name>/forwards`. See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for details.
+> **Note:** These are Solo's default port targets. If a port is already in use on your machine, Solo automatically selects the next available port. The actual ports used are printed at the end of deployment and saved to `~/.solo/<deployment-name>/forwards`. See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for details.
 
 **Solo 0.62 and earlier** used different default ports:
 

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -128,11 +128,53 @@ Confirm that all Solo-related pods are in a `Running` or `Completed` state.
 
 ## Access your local network
 
-After the one-shot deployment completes and all pods are running, your local services are available at the following endpoints:
+After the one-shot deployment completes and all pods are running, Solo sets up port-forwards so you can reach your local services. The endpoints below are the **default** ports for Solo 0.63 and later:
 
-| Service               | Endpoint                | Description                            | Verification
-|-----------------------|-------------------------|----------------------------------------|-------------------------------------|
-| Explorer UI           | `http://localhost:38080`| Web UI for inspecting the network.     | Open URL in your browser to view the network explorer |
-| Consensus node (gRPC) | `localhost:30211`       | gRPC endpoint for transactions.        | `nc -zv localhost 35211`            |
-| Mirror node REST API  | `http://localhost:38081`| REST API for queries.                  | http://localhost:38081/api/v1/transactions |
-| JSON RPC relay | `localhost:37546` | Ethereum-compatible JSON RPC endpoint. | <code>curl -X POST http://localhost:37546 -H 'Content-Type: application/json'<br>-d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'</code> |
+| Service               | Endpoint                 | Description                            | Verification |
+|-----------------------|--------------------------|----------------------------------------|--------------|
+| Explorer UI           | `http://localhost:38080` | Web UI for inspecting the network.     | Open URL in your browser |
+| Consensus node (gRPC) | `localhost:35211`        | gRPC endpoint for transactions.        | `nc -zv localhost 35211` |
+| Mirror node REST API  | `http://localhost:38081` | REST API for queries.                  | `curl http://localhost:38081/api/v1/transactions` |
+| JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint. | `curl -X POST http://localhost:37546 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'` |
+
+Open `http://localhost:38080` in your browser to explore your network.
+
+### Port availability
+
+The ports above are Solo's defaults. Solo uses `kubectl port-forward` to tunnel traffic from your machine to services running inside Kubernetes. Before opening each tunnel, Solo tries the configured port:
+
+- If the port is free, Solo logs: `Using requested port <port>`.
+- If the port is already occupied (by another process, or by a previous Solo session that did not clean up its port-forwards), Solo finds the next available port and logs: `Using available port <port>`.
+
+The actual ports used are printed at the end of `solo one-shot single deploy` and saved to a file. To see them:
+
+  ```bash
+  cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards
+  ```
+
+To check deployment info including port assignments:
+
+  ```bash
+  solo deployment config info --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
+  ```
+
+To restore port-forwards after a system restart without redeploying:
+
+  ```bash
+  solo deployment refresh port-forwards --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
+  ```
+
+### Endpoints for Solo 0.62 and earlier
+
+If you are using Solo 0.62 or earlier, the default port-forward targets differ:
+
+| Service               | Endpoint                | Description                            |
+|-----------------------|-------------------------|----------------------------------------|
+| Explorer UI           | `http://localhost:8080` | Web UI for inspecting the network.     |
+| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for transactions.        |
+| Mirror node REST API  | `http://localhost:8081` | REST API for queries (via mirror-ingress). |
+| JSON RPC relay        | `http://localhost:7546` | Ethereum-compatible JSON RPC endpoint. |
+
+Open `http://localhost:8080` in your browser to explore your network.
+
+> **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible only via manual `kubectl port-forward`, and is being phased out. Always use the ingress-based port (`8081` for Solo 0.62 and earlier, `38081` for Solo 0.63+).

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -146,7 +146,11 @@ The ports above are Solo's defaults. Solo uses `kubectl port-forward` to tunnel 
 - If the port is free, Solo logs: `Using requested port <port>`.
 - If the port is already occupied (by another process, or by a previous Solo session that did not clean up its port-forwards), Solo finds the next available port and logs: `Using available port <port>`.
 
-The actual ports used are printed at the end of `solo one-shot single deploy` and saved to a file. To see them:
+The actual ports used are printed at the end of `solo one-shot single deploy` and saved to a file.
+
+> **Note:** The commands below use `$(cat ~/.solo/cache/last-one-shot-deployment.txt)` to look up the deployment name automatically. This cache file is **only created by `solo one-shot` commands**. If you deployed using individual CLI commands, this file does not exist - find your deployment name with `solo deployment list` instead, then substitute it in place of the `$(cat ...)` subshell.
+
+To see the active port assignments:
 
   ```bash
   cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards

--- a/content/en/docs/troubleshooting.md
+++ b/content/en/docs/troubleshooting.md
@@ -190,28 +190,30 @@ If you cannot connect to Solo network endpoints from your machine, use this sequ
 
 2. Use manual port forwarding (bypass automation)
 
-   If automatic port forwarding (from `solo` commands or your environment) is not working, forward the required services manually:
+   If automatic port forwarding (from `solo` commands or your environment) is not working, forward the required services manually. The local ports below match the Solo 0.63+ defaults — adjust to any available port if needed:
 
    ```bash
-   # Consensus node (gRPC)
-   kubectl port-forward svc/haproxy-node1-svc -n "${SOLO_NAMESPACE}" 50211:50211 &
+   # Consensus node (gRPC) — local port 35211 → service port 50211
+   kubectl port-forward svc/haproxy-node1-svc -n "${SOLO_NAMESPACE}" 35211:50211 &
 
-   # Explorer UI
-   kubectl port-forward svc/hiero-explorer -n "${SOLO_NAMESPACE}" 8080:8080 &
+   # Explorer UI — local port 38080 → service port 8080
+   kubectl port-forward svc/hiero-explorer -n "${SOLO_NAMESPACE}" 38080:8080 &
+
+   # Mirror node ingress (REST API) — local port 38081 → service port 80
+   kubectl port-forward svc/mirror-1-rest -n "${SOLO_NAMESPACE}" 38081:80 &
 
    # Mirror node gRPC
    kubectl port-forward svc/mirror-1-grpc -n "${SOLO_NAMESPACE}" 5600:5600 &
 
-   # Mirror node REST
-   kubectl port-forward svc/mirror-1-rest -n "${SOLO_NAMESPACE}" 5551:80 &
-
-   # JSON-RPC relay
-   kubectl port-forward svc/relay-node1-hedera-json-rpc-relay -n "${SOLO_NAMESPACE}" 7546:7546 &
+   # JSON-RPC relay — local port 37546 → service port 7546
+   kubectl port-forward svc/relay-node1-hedera-json-rpc-relay -n "${SOLO_NAMESPACE}" 37546:7546 &
    ```
+
+   > **Note:** For Solo 0.62 and earlier, use local ports `50211`, `8080`, `5551`, and `7546` respectively.
 
 3. Confirm the expected endpoints and ports
 
-   After forwarding, connect to the local ports shown above (for example, `http://localhost:8080` for the explorer).  
+   After forwarding, connect to the local ports shown above (for example, `http://localhost:38080` for the explorer).  
    For the standard exposed endpoints after a successful one-shot deployment, see [How to access exposed services (mirror node, relay, explorer)](/docs/faqs#accessing-exposed-services).
 
 ---

--- a/content/en/docs/troubleshooting.md
+++ b/content/en/docs/troubleshooting.md
@@ -171,6 +171,73 @@ See [System readiness](/docs/simple-solo-setup/system-readiness#hardware-require
 
 ---
 
+### JSON-RPC Relay Out of Memory
+
+If the relay or relay-ws pods are being killed (`OOMKilled`) or restarting due to memory pressure, the sections below explain why this happens and how to resolve it.
+
+#### Understanding the default memory configuration
+
+Solo ships with a default memory limit of **88Mi** and an explicit V8 old-space cap of **66MB** (`--max-old-space-size=66`) for both the relay and WebSocket services. These values are tuned for the one-shot development profile and may not be sufficient for heavy workloads.
+
+#### How Node.js memory works in containers
+
+Since [Node.js 12.7.0](https://nodejs.org/en/blog/release/v12.7.0), Node.js reads the Linux cgroup memory limit set by Kubernetes to determine the V8 old-space heap size, rather than using the host's physical memory. Based on V8's internal heap sizing heuristics, this tends to be roughly **~50% of the container memory limit** on 64-bit systems, though the exact value depends on V8 internals and varies at both ends of the memory spectrum.
+
+A couple of things to be aware of:
+
+- **cgroup v2 environments**: many modern Linux distributions enable cgroup v2 by default, and [Kubernetes 1.25 brought cgroup v2 support to GA](https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/). Older Node.js versions may not correctly detect the container limit under cgroup v2 and could silently fall back to the host's physical memory, allocating a much larger heap than intended. This was improved in at least **Node.js 20.3.0**, which upgraded libuv to 1.45.0.
+- When `--max-old-space-size` is explicitly set (as in Solo's default config), it **overrides** the auto-sizing entirely — the cgroup-based detection only kicks in when no explicit value is provided.
+
+This means:
+
+- If you increase only the pod memory limit (e.g., to 256Mi) but leave `NODE_OPTIONS` unchanged, old space stays at 66 MB.
+- If you remove `NODE_OPTIONS`, Node.js will attempt to auto-size old space based on the container limit (roughly ~128 MB for a 256Mi pod on a modern Node.js version).
+
+#### Adjusting memory for heavier workloads
+
+Create a custom values file (e.g., `custom-relay-values.yaml`) and pass it when deploying:
+
+```yaml
+# Option 1: Explicit old-space control (recommended for precise tuning)
+relay:
+  resources:
+    limits:
+      memory: 256Mi
+  config:
+    NODE_OPTIONS: "--max-old-space-size=192"
+ws:
+  resources:
+    limits:
+      memory: 256Mi
+  config:
+    NODE_OPTIONS: "--max-old-space-size=192"
+
+# Option 2: Let Node.js auto-detect (simpler, old space ≈ 50% of limit)
+# relay:
+#   resources:
+#     limits:
+#       memory: 256Mi
+#   config:
+#     NODE_OPTIONS: ""
+# ws:
+#   resources:
+#     limits:
+#       memory: 256Mi
+#   config:
+#     NODE_OPTIONS: ""
+```
+
+Then deploy or upgrade with:
+
+```bash
+solo relay node add --deployment "${SOLO_DEPLOYMENT}" --values-file custom-relay-values.yaml
+# or
+solo relay node upgrade --deployment "${SOLO_DEPLOYMENT}" --values-file custom-relay-values.yaml
+```
+
+---
+
+
 ### Connection refused errors
 
 If you cannot connect to Solo network endpoints from your machine, use this sequence to isolate the issue.

--- a/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
+++ b/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
@@ -14,10 +14,12 @@ type: docs
 The Hiero Mirror Node stores the full transaction history of your local Solo network
 and exposes it through several interfaces:
 
-- A **web-based block explorer** (Hiero Mirror Node Explorer) at `http://localhost:8080`.
-- A **REST API** via the mirror-ingress service at `http://localhost:8081`
-    (recommended entry point-routes to the correct REST implementation).
+- A **web-based block explorer** (Hiero Mirror Node Explorer) at `http://localhost:38080/localnet/dashboard` (Solo 0.63+) or `http://localhost:8080/localnet/dashboard` (Solo 0.62 and earlier).
+- A **REST API** via the mirror-ingress service at `http://localhost:38081` (Solo 0.63+) or `http://localhost:8081` (Solo 0.62 and earlier)
+    (recommended entry point — routes to the correct REST implementation).
 - A **gRPC endpoint** for mirror node subscriptions.
+
+> **Important:** The port numbers in this document are Solo's default targets. If any port is already in use on your machine when Solo starts, Solo automatically selects the next available port. If an endpoint does not work, check the actual ports assigned to your deployment — see [Port Reference](#port-reference) below.
 
 This guide walks you through adding Mirror Node and the Hiero Explorer to a
 Solo network, and shows you how to query transaction data and create accounts.
@@ -116,8 +118,11 @@ solo explorer node add \
 Once Mirror Node is running, open the Hiero Explorer in your browser at:
 
 ```url
-http://localhost:8080
+http://localhost:38080/localnet/dashboard
 ```
+
+> **Note:** If you are using Solo 0.62 or earlier, the Explorer is at `http://localhost:8080/localnet/dashboard`.
+> If that port does not work, check the actual port assigned to your deployment — see [Port Reference](#port-reference).
 
 The Explorer lets you browse accounts, transactions, tokens, and contracts on
 your Solo network in real time.
@@ -133,8 +138,7 @@ solo ledger account create --deployment solo-deployment --hbar-amount 100
 solo ledger account create --deployment solo-deployment --hbar-amount 100
 ```
 
-Open the Explorer at `http://localhost:8080` to see the new accounts and their
-transactions recorded by the Mirror Node.
+Open the Explorer at `http://localhost:38080/localnet/dashboard` (Solo 0.63+) or `http://localhost:8080/localnet/dashboard` (Solo 0.62 and earlier) to see the new accounts and their transactions recorded by the Mirror Node. If the port does not work, check your actual port assignments — see [Port Reference](#port-reference).
 
 You can also use the [Hiero JavaScript SDK](/docs/using-solo/using-solo-with-javascript-sdk)
 to create a topic, submit a message, and subscribe to it.
@@ -143,23 +147,24 @@ to create a topic, submit a message, and subscribe to it.
 
 ## Step 4: Access Mirror Node APIs
 
-### Option A: Mirror-Ingress (localhost:8081)
+### Option A: Mirror-Ingress (localhost:38081)
 
-Use `localhost:8081` for all Mirror Node REST API access. The mirror-ingress
+Use `localhost:38081` (Solo 0.63+) for all Mirror Node REST API access. The mirror-ingress
 service routes requests to the correct REST implementation automatically. This
 is important because certain endpoints are only supported in the newer
 `rest-java` version.
 
 ```bash
 # List recent transactions
-curl -s "http://localhost:8081/api/v1/transactions?limit=5"
+curl -s "http://localhost:38081/api/v1/transactions?limit=5"
 
 # Get account details
-curl -s "http://localhost:8081/api/v1/accounts/0.0.2"
+curl -s "http://localhost:38081/api/v1/accounts/0.0.2"
 ```
 
-> **Note:** `localhost:5551` (the legacy Mirror Node REST API) is being phased
-> out. Always use `localhost:8081` to ensure compatibility with all endpoints.
+> **Note:** If you are using Solo 0.62 or earlier, use `localhost:8081` instead of `localhost:38081`.
+> `localhost:5551` (the legacy Mirror Node REST API direct endpoint) is being phased
+> out. Always use the mirror-ingress port to ensure compatibility with all endpoints.
 
 If you need to access it directly:
 
@@ -194,11 +199,35 @@ kubectl port-forward service/mirror-1-restjava -n "${SOLO_NAMESPACE}" 8084:80 &
 curl -s "http://${REST_IP:-127.0.0.1}:8084/api/v1/accounts/0.0.2/allowances/nfts"
 ```
 
-In most cases you should use `localhost:8081` instead.
+In most cases you should use `localhost:38081` (Solo 0.63+) or `localhost:8081` (Solo 0.62 and earlier) instead.
 
 ---
 
 ## Port Reference
+
+The ports listed below are Solo's **default** targets. Solo checks each port before opening a tunnel — if the port is already in use, Solo picks the next available one and logs `Using available port <port>`. If an endpoint is not reachable, check the actual ports used by your deployment:
+
+```bash
+# View the saved port-forward assignments
+cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards
+
+# Or query deployment info directly
+solo deployment config info --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
+```
+
+The default local ports depend on your Solo version:
+
+**Solo 0.63 and later (current defaults):**
+
+| Service | Local Port | Access Method |
+| --- | --- | --- |
+| Hiero Explorer | `38080` | Browser (`--enable-ingress`) |
+| Mirror Node (all-in-one) | `38081` | HTTP (`--enable-ingress`) |
+| Mirror Node REST API | `5551` | `kubectl port-forward` (manual) |
+| Mirror Node gRPC | `5600` | `kubectl port-forward` |
+| Mirror Node REST Java | `8084` | `kubectl port-forward` |
+
+**Solo 0.62 and earlier:**
 
 | Service | Local Port | Access Method |
 | --- | --- | --- |

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -55,20 +55,22 @@ This command:
 
 - Creates a local Kind Kubernetes cluster.
 - Deploys a Hiero consensus node, mirror node, and Hiero Mirror Node Explorer.
-- Deploys the Hiero **JSON-RPC relay** and exposes it at `http://localhost:7546`.
+- Deploys the Hiero **JSON-RPC relay** and exposes it at `http://localhost:37546` (Solo 0.63+).
 - Generates three groups of pre-funded accounts, including ECDSA (EVM-compatible) accounts.
 
-> **Relay endpoint summary:**
+> **Relay endpoint summary (Solo 0.63 and later):**
 >
 > | Property | Value |
 > | --- | --- |
-> | RPC URL | `http://localhost:7546` |
+> | RPC URL | `http://localhost:37546` |
 > | Chain ID | `298` |
 > | Currency symbol | `HBAR` |
+>
+> If you are using Solo 0.62 or earlier, the relay is at `http://localhost:7546`.
 
 ### Adding the Relay to an Existing Deployment
 
-If you already have a running Solo network without the relay, see [**Step 10: Deploy JSON-RPC Relay**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#10-deploy-json-rpc-relay) in the Step-by-Step Manual Deployment guide for full instructions, then return here once your relay is running on `http://localhost:7546`.
+If you already have a running Solo network without the relay, see [**Step 10: Deploy JSON-RPC Relay**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#10-deploy-json-rpc-relay) in the Step-by-Step Manual Deployment guide for full instructions, then return here once your relay is running on `http://localhost:37546` (Solo 0.63+) or `http://localhost:7546` (Solo 0.62 and earlier).
 
 To remove the relay when you no longer need it, see [**Cleanup Step 1: Destroy JSON-RPC Relay**](/docs/advanced-solo-setup/network-deployments/manual-deployment/#1-destroy-json-rpc-relay) in the same guide.
 
@@ -161,7 +163,7 @@ const config: HardhatUserConfig = {
   solidity: "0.8.28",
   networks: {
     solo: {
-      url: "http://127.0.0.1:7546",
+      url: "http://127.0.0.1:37546",
       chainId: 298,
       // Load from environment — never commit private keys to source control
       accounts: process.env.SOLO_EVM_PRIVATE_KEY
@@ -317,8 +319,10 @@ Confirm your transactions reached consensus using any of the following:
 ### Hiero Mirror Node Explorer
 
 ```url
-http://localhost:8080/localnet/dashboard
+http://localhost:38080/localnet/dashboard
 ```
+
+> **Note:** If you are using Solo 0.62 or earlier, the Explorer is at `http://localhost:8080/localnet/dashboard`.
 
 Search by account address, transaction hash, or contract address to view
 transaction details and receipts.
@@ -326,19 +330,19 @@ transaction details and receipts.
 ### Hiero Mirror Node REST API
 
 ```url
-http://localhost:8081/api/v1/transactions?limit=5
+http://localhost:38081/api/v1/transactions?limit=5
 ```
 
 Returns the five most recent transactions in JSON format. Useful for scripted
 verification.
 
-> Note: `localhost:5551` (the legacy Mirror Node REST API) is being phased out.
-> Always use `localhost:8081` to ensure compatibility with all endpoints.
+> Note: `localhost:5551` (the legacy Mirror Node REST API direct endpoint) is being phased out.
+> Use `localhost:38081` (Solo 0.63+) or `localhost:8081` (Solo 0.62 and earlier) to ensure compatibility with all endpoints.
 
 ### Hiero JSON RPC Relay (eth_getTransactionReceipt)
 
 ```bash
-curl -X POST http://localhost:7546 \
+curl -X POST http://localhost:37546 \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xYOUR_TX_HASH"],"id":1}'
 ```
@@ -356,10 +360,12 @@ To connect MetaMask to your local Solo network:
    | Field | Value |
    | --- | --- |
    | Network name | `Solo Local` |
-   | New RPC URL | `http://localhost:7546` |
+   | New RPC URL | `http://localhost:37546` |
    | Chain ID | `298` |
    | Currency symbol | `HBAR` |
-   | Block explorer URL | `http://localhost:8080/localnet/dashboard` (optional) |
+   | Block explorer URL | `http://localhost:38080/localnet/dashboard` (optional) |
+
+   > **Note:** If you are using Solo 0.62 or earlier, use `http://localhost:7546` for the RPC URL and `http://localhost:8080/localnet/dashboard` for the block explorer URL.
 
 3. Click **Save** and switch to the **Solo Local** network.
 4. Import an account using an ECDSA private key from `accounts.json`:
@@ -415,13 +421,13 @@ details.
 
 | Symptom | Likely Cause | Fix |
 | --- | --- | --- |
-| `connection refused` on port `7546` | Relay not running | Run `one-shot single deploy` or `solo relay node add` |
+| `connection refused` on port `37546` | Relay not running | Run `one-shot single deploy` or `solo relay node add` |
 | `invalid sender` or signature error | Using ED25519 key instead of ECDSA | Use ECDSA keys from `accounts.json` |
 | Hardhat `chainId` mismatch error | Missing or wrong `chainId` in config | Set `chainId: 298` in `hardhat.config.ts` |
 | MetaMask shows wrong network | Chain ID mismatch | Ensure Chain ID is `298` in MetaMask network settings |
 | `INSUFFICIENT_TX_FEE` on transaction | Account not funded | Use a pre-funded ECDSA account from `accounts.json` |
 | Hardhat test timeout | Network not fully started | Wait for `one-shot` to fully complete before running tests |
-| Port `7546` already in use | Another process is using the port | Run `lsof -i :7546` and stop the conflicting process |
+| Port `37546` already in use | Another process is using the port | Run `lsof -i :37546` and stop the conflicting process |
 
 ---
 


### PR DESCRIPTION
**Description**:

- Update service endpoints for Solo 0.63+ and document legacy ports as per this Slack conversation: https://swirldslabs.slack.com/archives/C0A1QLVMD5X/p1776282202239739

- Adds a new JSON-RPC Relay Out of Memory troubleshooting section 

Fixes #72 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
