### PR TITLE
[codex] docs: add one-shot edge version environment variables

### DIFF
--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -184,3 +184,8 @@ commands.
 | --- | --- | ---
 | `ONE_SHOT_WITH_BLOCK_NODE` | Deploy Block Node as part of a one-shot deployment | `false`
 | `MIRROR_NODE_PINGER_TPS` | Transactions per second for the Mirror Node monitor pinger. Set to `0` to disable | `5`
+| `CONSENSUS_NODE_EDGE_VERSION` | Edge (newer-than-default) consensus node version used by `--edge` in one-shot deploys. Falls back to `CONSENSUS_NODE_VERSION`. | `v0.74.0-rc.1`
+| `MIRROR_NODE_EDGE_VERSION` | Edge mirror node version used by `--edge` in one-shot deploys. Falls back to `MIRROR_NODE_VERSION`. | `v0.153.1`
+| `EXPLORER_EDGE_VERSION` | Edge explorer version used by `--edge` in one-shot deploys. Falls back to `EXPLORER_VERSION`. | `26.0.0`
+| `RELAY_EDGE_VERSION` | Edge relay version used by `--edge` in one-shot deploys. Falls back to `RELAY_VERSION`. | `0.76.2`
+| `BLOCK_NODE_EDGE_VERSION` | Edge block node version used by `--edge` in one-shot deploys. Falls back to `BLOCK_NODE_VERSION`. | `0.31.0`


### PR DESCRIPTION
## What Changed
- Added 5 `--edge` one-shot deployment environment variable rows to `using-environment-variables.md`:
  - `CONSENSUS_NODE_EDGE_VERSION`
  - `MIRROR_NODE_EDGE_VERSION`
  - `EXPLORER_EDGE_VERSION`
  - `RELAY_EDGE_VERSION`
  - `BLOCK_NODE_EDGE_VERSION`

## Why
- The environment variable reference was missing the edge-version overrides used by one-shot deploy flows.
- This update keeps docs aligned with current Solo environment configuration behavior.

## Impact
- Operators can discover and configure edge version overrides directly from docs.
- Reduces ambiguity around how `--edge` resolves component versions.

## Validation
- Verified the doc section includes only the intended new rows in the `One-Shot Deployment` table.
