### PR TITLE
update env docs

### DIFF
--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -118,6 +118,13 @@ commands.
 | `RELAY_PODS_READY_MAX_ATTEMPTS` | Maximum number of attempts to check if relay pods are ready | `100`
 | `RELAY_PODS_READY_DELAY` | Interval between relay pod ready checks, in milliseconds | `1000`
 
+## Mirror Node
+
+| Environment Variable | Description | Default Value
+| --- | --- | ---
+| `DISABLE_IMPORTER_SPRING_PROFILES` | Disable automatic configuration of Mirror Node importer Spring profiles for block-node integration. | `false`                                                                                            |
+| `SPRING_PROFILES_ACTIVE` | Spring profiles to use for the Mirror Node importer when automatic importer profile configuration is enabled. | `blocknode`                                                                                        |
+
 ---
 
 ## Load Balancer


### PR DESCRIPTION
**Description**:

Added new section `Mirror Node` to `using-environment-variables.md`

Add new envs to docs:
- `DISABLE_IMPORTER_SPRING_PROFILES` (default: `false`) allows leaving the `SPRING_PROFILES_ACTIVE` unset, for the mirror node block node integration values.
- `SPRING_PROFILES_ACTIVE` (default: `blocknode`) allows overriding the `SPRING_PROFILES_ACTIVE` for the mirror node block node integration values.

**Related issue(s)**:

Fixes # N/A
Reladted to # https://github.com/hiero-ledger/solo/pull/4414

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
