### PR TITLE
docs: sync falcon prepare docs

### DIFF
--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-deployment.md
@@ -69,6 +69,38 @@ to the underlying Solo subcommands.
 For the full list of supported CLI flags per section, see the
 [**Falcon Values File Reference**](/docs/advanced-solo-setup/network-deployments/falcon-flags-reference).
 
+## Prepare a Falcon values file
+
+Instead of authoring a values file by hand, you can use the interactive `prepare` wizard to generate one:
+
+```bash
+solo one-shot falcon prepare
+```
+
+The wizard prompts for component toggles (mirror node, explorer, relay), consensus node count, component versions, ingress, storage type, developer options, and port forwarding. All prompts have sensible defaults, so you can press Enter to accept them.
+
+To generate a values file with all defaults (no prompts):
+
+```bash
+solo one-shot falcon prepare --quiet-mode
+```
+
+To specify a custom output path:
+
+```bash
+solo one-shot falcon prepare --output-values-file ./my-values.yaml
+```
+
+### Output file location
+
+By default, the generated file is written to `~/.solo/cache/falcon-values.yaml` — a deterministic absolute path regardless of how or where Solo is invoked. You can override this with `--output-values-file`. The success message always prints the fully resolved path so there is no ambiguity.
+
+- **Default**: `~/.solo/cache/falcon-values.yaml` — always the same location.
+- **Relative path**: `--output-values-file ./configs/my-values.yaml` — resolved against the current working directory (so `/tmp/configs/my-values.yaml` if invoked from `/tmp`).
+- **Absolute path**: `--output-values-file /tmp/falcon-values.yaml` — written to that exact location regardless of the current working directory.
+
+The generated file is ready to use with `solo one-shot falcon deploy --values-file`. For the full list of flags the wizard sets, see the [Falcon Values File Reference](/docs/advanced-solo-setup/network-deployments/falcon-flags-reference).
+
 ## Create a Falcon Values File
 
 Create a YAML file to control every component of your Solo deployment. The file can have any name -`falcon-values.yaml` is used throughout this guide as a convention.

--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-flags-reference.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-flags-reference.md
@@ -235,3 +235,16 @@ line. They are **not** read from the values file sections.
 | `--parallel-deploy` | boolean | `true` | Run independent deploy stages in parallel (consensus+block, mirror+accounts, explorer+relay). Use `--no-parallel-deploy` for sequential execution. |
 | `--quiet-mode` | boolean | `false` | Suppress all interactive prompts. |
 | `--force` | boolean | `false` | Force actions that would otherwise be skipped. |
+
+---
+
+## Falcon Prepare — `prepare`
+
+Flags accepted by `solo one-shot falcon prepare`, the interactive wizard that generates a Falcon values file. The wizard prompts for nearly every values-file field, but the following CLI flags control its output behavior directly.
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--output-values-file` | string | `~/.solo/cache/falcon-values.yaml` | Path to the generated values file. Absolute paths are written as-is. Relative paths are resolved against the current working directory. |
+| `--quiet-mode` | boolean | `false` | Generate a values file using all defaults without prompting. |
+
+All other `prepare`-time flags correspond directly to the per-section values shown in the tables above and are documented under their respective `network`, `setup`, `consensusNode`, `mirrorNode`, `explorerNode`, `relayNode`, and `blockNode` sections.


### PR DESCRIPTION
Documents the `solo one-shot falcon prepare` interactive wizard added upstream in hiero-ledger/solo#3879. Two additions:

- falcon-deployment.md: new "Prepare a Falcon values file" H2 placed before "Create a Falcon Values File" so readers see the wizard path first and the manual-authoring path right after as the alternative. Covers the --quiet-mode and --output-values-file flags and the output-path resolution rules (default ~/.solo/cache/falcon-values.yaml, relative-to-CWD, absolute as-is).

- falcon-flags-reference.md: new "Falcon Prepare — prepare" section after "Top-Level Falcon Command Flags", documenting only the two prepare-specific flags and pointing back at the per-section tables for everything else the wizard sets.

Lint note: both files were already failing prettier --check on main before this change. This PR introduces no new prettier or cspell violations; pre-existing formatting drift left untouched to keep the diff focused on content.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
