### PR TITLE
docs(ux): copy buttons, sidebar toggle, and cover-page Next

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1847,3 +1847,114 @@ html:not([data-bs-theme='dark']) {
   }
 }
 
+// --- 14. UX ENHANCEMENTS ---
+// Issue #149: click-to-copy on inline <code> elements (including inside tables).
+// Issue #150: collapsible sidebar toggle.
+
+// Click-to-copy affordance on inline code. Fenced code blocks already have
+// Docsy's own copy button; this targets the `<code>` elements outside <pre>.
+code.click-to-copy {
+  cursor: pointer;
+  position: relative;
+  transition: background-color var(--transition-duration) var(--transition-timing);
+
+  &:hover {
+    background-color: var(--color-primary-very-light);
+  }
+}
+
+// "Copied!" indicator: brief tooltip that fades in then out.
+code.click-to-copy.code-copied::after {
+  content: 'Copied!';
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 2px 8px;
+  background: var(--color-text-dark);
+  color: var(--color-bg-white);
+  border-radius: var(--border-radius-sm);
+  font-family: var(--font-family-primary);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 1000;
+  animation: codeCopiedFade 1.2s ease-out forwards;
+}
+
+@keyframes codeCopiedFade {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 4px);
+  }
+  15%,
+  70% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -4px);
+  }
+}
+
+// Sidebar collapse toggle button in the navbar.
+.sidebar-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-right: 0.5rem;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--border-radius-sm);
+  color: var(--color-text-dark);
+  cursor: pointer;
+  transition: background-color var(--transition-duration) var(--transition-timing),
+              border-color var(--transition-duration) var(--transition-timing);
+
+  &:hover {
+    background-color: var(--color-bg-light);
+    border-color: var(--color-border);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+// Collapsed-sidebar layout: hide sidebar (and right TOC sidebar) and let the
+// main content take the recovered width. Scoped to wide screens; mobile keeps
+// Docsy's existing off-canvas behavior.
+@media (min-width: 768px) {
+  body.sidebar-collapsed {
+    .td-sidebar,
+    .td-sidebar-toc {
+      display: none !important;
+    }
+
+    .td-main > .row.flex-xl-nowrap > main[role='main'] {
+      flex: 1 1 100% !important;
+      max-width: 100% !important;
+    }
+  }
+}
+
+// Dark-mode parity for the toggle button.
+[data-bs-theme='dark'] .sidebar-toggle {
+  color: #edf2ff;
+
+  &:hover {
+    background-color: #1f2737;
+    border-color: var(--color-border);
+  }
+}
+

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -140,7 +140,7 @@ params:
     taxonomyCloudTitle: [Categories, Tag Cloud]
 
     # set taxonomyPageHeader = [] to hide taxonomies on the page headers
-    taxonomyPageHeader: [categories, tags]
+    taxonomyPageHeader: []
 
   privacy_policy: https://policies.google.com/privacy
 

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -11,9 +11,14 @@
 	{{ .Render "_td-content-after-header" -}}
 	{{ .Content }}
 	{{ partial "section-index.html" . -}}
-	{{/* Allow explicit cross-section prev/next overrides via front matter */}}
+	{{/* Default `next` on cover pages: first child page by weight.
+	     Allow explicit cross-section prev/next overrides via front matter.
+	     Issue: https://github.com/hiero-ledger/solo-docs/issues/150 */}}
 	{{ $previous := false -}}
 	{{ $next := false -}}
+	{{ with (where .Pages "Section" .Section).ByWeight -}}
+		{{ $next = index . 0 -}}
+	{{ end -}}
 	{{ with .Params.nav_prev }}{{ $previous = site.GetPage . }}{{ end -}}
 	{{ with .Params.nav_next }}{{ $next = site.GetPage . }}{{ end -}}
 	{{ if or $previous $next -}}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,24 +1,4 @@
 <script>
-  // Expand all foldable sidebar sections by default.
-  // Docsy's foldable-nav uses hidden checkboxes; checking them opens the section.
-  // Individual sections can still be collapsed by the user after load.
-  (function () {
-    function expandSidebarSections() {
-      document
-        .querySelectorAll('nav.foldable-nav input[type="checkbox"]')
-        .forEach(function (cb) {
-          cb.checked = true;
-        });
-    }
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', expandSidebarSections);
-    } else {
-      expandSidebarSections();
-    }
-  })();
-</script>
-
-<script>
   // Enable typeahead behavior for Docsy offline search.
   // Docsy binds search rendering to the "change" event (Enter/blur), so we
   // dispatch debounced "change" events while typing.
@@ -70,6 +50,135 @@
       document.addEventListener('DOMContentLoaded', enableTypeaheadSearch);
     } else {
       enableTypeaheadSearch();
+    }
+  })();
+</script>
+
+<script>
+  // Click-to-copy on inline <code> elements (not inside <pre>).
+  // Docsy already handles fenced code blocks; this covers the gap for inline
+  // code, including inline <code> rendered inside <table> cells.
+  // Issue: https://github.com/hiero-ledger/solo-docs/issues/149
+  (function () {
+    function copyText(text) {
+      if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+      }
+      // Fallback for non-secure contexts / older browsers.
+      return new Promise(function (resolve, reject) {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {
+          document.execCommand('copy') ? resolve() : reject();
+        } catch (e) {
+          reject(e);
+        } finally {
+          document.body.removeChild(ta);
+        }
+      });
+    }
+
+    function flashCopied(el) {
+      el.classList.add('code-copied');
+      setTimeout(function () {
+        el.classList.remove('code-copied');
+      }, 1200);
+    }
+
+    function attachClickToCopy() {
+      document.querySelectorAll('code').forEach(function (el) {
+        if (el.closest('pre')) return;
+        if (el.dataset.copyBound === '1') return;
+        el.dataset.copyBound = '1';
+        el.classList.add('click-to-copy');
+        el.setAttribute('title', 'Click to copy');
+        el.addEventListener('click', function () {
+          copyText(el.textContent || '').then(
+            function () { flashCopied(el); },
+            function () { /* ignore */ }
+          );
+        });
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', attachClickToCopy);
+    } else {
+      attachClickToCopy();
+    }
+  })();
+</script>
+
+<script>
+  // Desktop sidebar collapse toggle.
+  // Adds a small button to the sidebar header that hides/shows the sidebar
+  // on wide screens. State persists in localStorage so it survives navigation.
+  // Issue: https://github.com/hiero-ledger/solo-docs/issues/150
+  (function () {
+    var STORAGE_KEY = 'solo-docs:sidebar-collapsed';
+
+    function applyState(collapsed) {
+      document.body.classList.toggle('sidebar-collapsed', collapsed);
+      var toggle = document.getElementById('sidebar-toggle');
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        toggle.setAttribute(
+          'title',
+          collapsed ? 'Show sidebar' : 'Hide sidebar'
+        );
+      }
+    }
+
+    function buildToggle() {
+      // Place the toggle in the navbar so it's always visible, even when the
+      // sidebar is hidden. Docsy renders the navbar at the top of the page.
+      var navbar = document.querySelector('.td-navbar .td-navbar-nav-scroller');
+      if (!navbar || document.getElementById('sidebar-toggle')) return;
+
+      var btn = document.createElement('button');
+      btn.id = 'sidebar-toggle';
+      btn.type = 'button';
+      btn.className = 'sidebar-toggle';
+      btn.setAttribute('aria-label', 'Toggle sidebar');
+      btn.innerHTML =
+        '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>';
+
+      btn.addEventListener('click', function () {
+        var nowCollapsed = !document.body.classList.contains(
+          'sidebar-collapsed'
+        );
+        try {
+          localStorage.setItem(STORAGE_KEY, nowCollapsed ? '1' : '0');
+        } catch (e) {
+          /* ignore quota / private-mode errors */
+        }
+        applyState(nowCollapsed);
+      });
+
+      navbar.insertBefore(btn, navbar.firstChild);
+    }
+
+    function init() {
+      var stored = null;
+      try {
+        stored = localStorage.getItem(STORAGE_KEY);
+      } catch (e) {
+        /* ignore */
+      }
+      applyState(stored === '1');
+      buildToggle();
+      applyState(document.body.classList.contains('sidebar-collapsed'));
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
     }
   })();
 </script>


### PR DESCRIPTION
**Description**:

Site UX improvements driven by reviewer feedback on the Solo Quickstart and SDK docs:

* Click-to-copy on inline `<code>` elements (the gap that fenced code blocks didn't have), including inline code inside tables.
* Collapsible sidebar toggle in the navbar, with the collapsed state persisted in `localStorage`.
* Default "Next →" link on cover/section index pages — picks the first child page by weight; existing `nav_next` front matter still wins as an override.
* Remove the per-article tag/category chips under page titles (`taxonomyPageHeader: []`). The dedicated `/tags/` and `/categories/` listing pages still work.
* Drop the force-expand-all sidebar JS so the sub-section folding follows Docsy's natural per-active-section behavior, which scales better as the doc tree grows.

**Related issue(s)**:

Closes
[Code blocks need copy buttons (especially in tables) #149](https://github.com/hiero-ledger/solo-docs/issues/149),
[Site UX: collapsible sidebar + "Next" button on cover pages #150](https://github.com/hiero-ledger/solo-docs/issues/150).

**Notes for reviewer**:

All four changes are theme-level overrides; they apply site-wide automatically. Verified locally with `hugo serve`: copy-on-click works in tables, sidebar toggle hides/shows the sidebar and persists across navigation, cover pages now show a Next link to their first child, article headers are clean.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)