### PR TITLE
Docs(fix 147): add two-line output for `nc -zv localhost 35211`

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -139,6 +139,15 @@ After the one-shot deployment completes and all pods are running, Solo sets up p
 | Mirror node REST API  | `http://localhost:38081` | REST API for queries.                  | `curl http://localhost:38081/api/v1/transactions` |
 | JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint. | `curl -X POST http://localhost:37546 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'` |
 
+Expected output for `nc -zv localhost 35211` on macOS:
+
+```text
+nc: connectx to localhost port 35211 (tcp) failed: Connection refused
+Connection to localhost port 35211 [tcp/*] succeeded!
+```
+
+> **Note:** The "Connection refused" line is the IPv6 connection attempt. The successful IPv4 connection follows immediately after. Both lines indicate a successful validation.
+
 Open `http://localhost:38080` in your browser to explore your network.
 
 ### Port availability

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -139,14 +139,13 @@ After the one-shot deployment completes and all pods are running, Solo sets up p
 | Mirror node REST API  | `http://localhost:38081` | REST API for queries.                  | `curl http://localhost:38081/api/v1/transactions` |
 | JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint. | `curl -X POST http://localhost:37546 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'` |
 
-Expected output for `nc -zv localhost 35211` on macOS:
-
-```text
-nc: connectx to localhost port 35211 (tcp) failed: Connection refused
-Connection to localhost port 35211 [tcp/*] succeeded!
-```
-
-> **Note:** The "Connection refused" line is the IPv6 connection attempt. The successful IPv4 connection follows immediately after. Both lines indicate a successful validation.
+> **macOS note:** Running `nc -zv localhost 35211` may print two lines:
+> ```text
+> nc: connectx to localhost port 35211 (tcp) failed: Connection refused
+> Connection to localhost port 35211 [tcp/*] succeeded!
+> ```
+> The first line is a failed IPv6 attempt - this is expected on macOS.
+> The second line confirms the IPv4 connection succeeded. The port is reachable.
 
 Open `http://localhost:38080` in your browser to explore your network.
 


### PR DESCRIPTION
**Description**:
as per Matt's feedback added two-line output for `nc -zv localhost 35211`

**Related issue(s)**:

Fixes #147 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
