### PR TITLE
docs: correct minimum Hugo version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The documentation covers:
 ### Prerequisites
 - Node.js 22+
 - Go (for Hugo extended)
-- Hugo extended 0.145.0+
+- Hugo extended 0.146.0+ (required by the Docsy theme; `npm install` also provides a pinned `hugo-extended`)
 
 ### Build and Preview
 


### PR DESCRIPTION
**Description**:
The README listed "Hugo extended 0.145.0+", but the Docsy theme requires >= 0.146.0 extended; building with 0.145.0 fails with an i18n translation error ("unsupported file format bool"). Bump the documented minimum to 0.146.0 and note that `npm install` provides a pinned hugo-extended.

**Related issue(s)**:

Fixes #173 

**Notes for reviewer**:
Ran the following on my local to test the result:
```
npm install
hugo --cleanDestinationDir
```
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
