### PR TITLE
docs(cleanup): straighten curly quotes to ASCII

### DIFF
--- a/content/en/docs/simple-solo-setup/cleanup.md
+++ b/content/en/docs/simple-solo-setup/cleanup.md
@@ -42,7 +42,7 @@ This command performs the following actions:
 
 If `solo one-shot single destroy` fails part-way through (for example, due to an earlier deploy error), some resources may remain:
 
-- The Solo namespace or one or more PVCs may not be deleted, which can leave Docker volumes appearing as “in use”.
+- The Solo namespace or one or more PVCs may not be deleted, which can leave Docker volumes appearing as "in use".
 - The destroy commands are designed to be idempotent, so you can safely rerun `solo one-shot single destroy` to complete cleanup.
 
 If rerunning destroy does not release the resources, use the **Full Reset** procedure below to force a clean state.


### PR DESCRIPTION
**Description**:
Replace the curly double quotes around "in use" with straight ASCII quotes for consistency with the rest of the docs.

**Related issue(s)**:

Fixes #137 

**Notes for reviewer**:
Tested the changes by running locally.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
