### PR TITLE
docs: update EVM Tools Hardhat examples to v3 API

### DIFF
--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -156,28 +156,34 @@ The `chainId` of `298` is required - Hardhat will reject transactions if it
 does not match the network:
 
 ```typescript
-import type { HardhatUserConfig } from "hardhat/config";
-import "@nomicfoundation/hardhat-toolbox";
+import { defineConfig } from "hardhat/config";
+import hardhatToolboxMochaEthers from "@nomicfoundation/hardhat-toolbox-mocha-ethers";
 
-const config: HardhatUserConfig = {
+const config = defineConfig({
+  plugins: [hardhatToolboxMochaEthers],
   solidity: "0.8.28",
   networks: {
-    solo: {
+    my_solo_deployment: {
+      type: "http",
       url: "http://127.0.0.1:37546",
       chainId: 298,
-      // Load from environment — never commit private keys to source control
+      // Load from environment - never commit private keys to source control
       accounts: process.env.SOLO_EVM_PRIVATE_KEY
         ? [process.env.SOLO_EVM_PRIVATE_KEY]
         : [],
     },
   },
-};
+});
 
 export default config;
 ```
 
-> **Important:** `chainId: 298` must be set explicitly. Without it, Hardhat's
-> network validation will fail when connecting to the Solo relay.
+> **Important:** This is the Hardhat v3 config format used by the bundled
+> example (Hardhat 3.x). Each network needs an explicit `type: "http"`, and
+> `chainId: 298` must be set - without `type`/`chainId`, Hardhat v3 fails with
+> `HHE40000: No network with chain id "298" found` when connecting to the relay.
+> The network key (`my_solo_deployment`) must match the `--network` flag you
+> pass to Hardhat commands.
 
 ---
 
@@ -256,10 +262,16 @@ npx hardhat run scripts/deploy.ts --network my_solo_deployment
 
 A minimal `scripts/deploy.ts` looks like:
 
+> **Hardhat v3:** The bundled example pins Hardhat 3.x, which removed the
+> `ethers` named export from the `hardhat` module. Obtain `ethers` from the
+> network connection with `const { ethers } = await network.connect()` instead
+> of `import { ethers } from "hardhat"`.
+
 ```typescript
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 
 async function main() {
+  const { ethers } = await network.connect();
   const SimpleStorage = await ethers.getContractFactory("SimpleStorage");
   const contract = await SimpleStorage.deploy(42);
   await contract.waitForDeployment();
@@ -280,9 +292,10 @@ main().catch((err) => {
 To submit a transaction directly from a script using ethers.js via Hardhat:
 
 ```typescript
-import { ethers } from "hardhat";
+import { network } from "hardhat";
 
 async function main() {
+  const { ethers } = await network.connect();
   const [sender] = await ethers.getSigners();
   console.log("Sender:", sender.address);
 


### PR DESCRIPTION
**Description**:
Implemented feedback recieved from Kiran and Jake on EVM Tools deploy.ts / send-tx.ts. The bundled hardhat-with-solo example pins Hardhat 3.x, but the docs used Hardhat v2 syntax that fails on v3.

**Related issue(s)**:

Fixes #142 

**Notes for reviewer**:
AI testing done

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)