### PR TITLE
docs: explain expected "Stopping port-forward" message during deploy

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -80,6 +80,11 @@ This command performs the following actions:
 - Sets up and funds default test accounts.
 - Exposes gRPC and JSON-RPC endpoints for client access.
 
+> **Note:** During deployment you may see `Stopping port-forward for port [N]`
+> printed in yellow. This is expected - as it sets up the network, Solo stops
+> and re-establishes port-forwards to finalize the port configuration (clearing
+> stale forwards and migrating ports as needed). It does not indicate a failure.
+
 ### What gets deployed
 
 | Component      | Description                                          |


### PR DESCRIPTION
**Description**:

Address #151: during `solo one-shot single deploy`, Solo prints `Stopping port-forward for port [N]` in yellow, which looks alarming on a first install. 
Add a Quickstart note that this is expected - Solo stops and re-establishes port-forwards to finalise the port configuration. 

**Related issue(s)**:

Fixes #151 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
