### PR TITLE
docs: add specific-version install guidance and consolidate upgrade/cleanup docs

### DIFF
--- a/content/en/docs/simple-solo-setup/cleanup.md
+++ b/content/en/docs/simple-solo-setup/cleanup.md
@@ -1,6 +1,6 @@
 ---
 title: "Cleanup"
-weight: 5
+weight: 6
 description: >
   Learn how to properly destroy a Solo network deployment, manage resource
   usage, and perform a full reset when the standard destroy command fails along with
@@ -92,3 +92,18 @@ docker volume prune
 > **Warning:** `docker volume prune` removes all unused Docker volumes on your machine, not just those created by Solo. Only run this command if you understand its impact.
 
 - To redeploy after a full reset, follow the [Quickstart](/docs/simple-solo-setup/quickstart) guide.
+
+## Clean up legacy npm installations
+
+If you previously installed Solo via npm (for example, from older workshops or
+documentation), remove the legacy global package to avoid conflicts with a
+newer Homebrew or npm install:
+
+```bash
+# Remove a legacy npm-based Solo install (safe to run even if not present)
+npm uninstall -g @hiero-ledger/solo
+```
+
+Then reinstall using the [Quickstart](/docs/simple-solo-setup/quickstart), or
+follow [Upgrading an existing Solo installation](/docs/simple-solo-setup/upgrading-solo)
+to move to a specific or latest version.

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -257,33 +257,12 @@ The following tools are not required but are recommended for monitoring and mana
 
 ## Troubleshooting Installation
 
-If you experience issues installing or upgrading Solo (for example, conflicts with a previous installation), you may need to clean up your environment first.
+If you experience issues installing or upgrading Solo - for example, conflicts
+with a previous installation - clean up your environment and reinstall:
 
-### Clean up legacy npm installations
-
-If you previously installed Solo via npm (for example, from older workshops or documentation), remove the legacy installation to avoid conflicts:
-
-```bash
-# Remove legacy npm-based Solo installation (if present)
-[[ "$(command -v npm >/dev/null 2>&1 && echo 0 || echo 1)" -eq 0 ]] && { npm uninstall -g @hiero-ledger/solo >/dev/null 2>&1 || /bin/true }
-```
-
-### Full environment reset
-
-> **Warning:** The commands below will delete Solo-managed Kind clusters and remove your Solo home directory (`~/.solo`).
-
-```bash
-# Delete only Solo-managed Kind clusters (names starting with "solo")
-kind get clusters | grep '^solo' | while read cluster; do
-  kind delete cluster -n "$cluster"
-done
-
-# Remove Solo configuration and cache
-rm -rf ~/.solo
-```
-
-After cleaning up, retry the installation with:
-
-```bash
-brew install hiero-ledger/tools/solo
-```
+- To **remove a legacy npm install** or perform a **full environment reset**
+  (delete Solo-managed Kind clusters and your `~/.solo` directory), see the
+  [Cleanup guide](/docs/simple-solo-setup/cleanup).
+- To **upgrade an existing install**, install a **specific version**, or switch
+  between Homebrew and npm, see
+  [Upgrading an existing Solo installation](/docs/simple-solo-setup/upgrading-solo).

--- a/content/en/docs/simple-solo-setup/upgrading-solo.md
+++ b/content/en/docs/simple-solo-setup/upgrading-solo.md
@@ -1,5 +1,5 @@
 ---
-title: "Upgrading Solo"
+title: "Upgrading an existing Solo installation"
 weight: 5
 description: >
   Upgrade an existing Solo installation to the latest release - whether you
@@ -52,6 +52,40 @@ npm install -g @hiero-ledger/solo@latest
 > `Helm`. After a major-version upgrade, re-check the required tool versions in
 > [System Readiness](/docs/simple-solo-setup/system-readiness).
 
+## Install a specific version
+
+To install a specific (non-latest) Solo release - for example, to reproduce a
+bug, run a regression test, or pin a version across a team - use a versioned
+Homebrew formula or npm tag instead of `latest`.
+
+{{< tabpane text=true >}}
+{{% tab header="Homebrew" lang="homebrew" %}}
+```bash
+brew install hiero-ledger/tools/solo@0.76.0
+```
+The tap publishes a versioned formula (`solo@<version>`) for each release.
+{{% /tab %}}
+{{% tab header="npm" lang="npm" %}}
+```bash
+npm install -g @hiero-ledger/solo@0.76.0
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+Confirm the installed version:
+
+```bash
+solo --version
+```
+
+> **Tip:** Installing a versioned formula or npm tag **pins** Solo to that
+> release - it will not move when you run `brew upgrade` or `npm update`. To
+> return to the latest release, follow
+> [Upgrade a Homebrew install](#upgrade-a-homebrew-install) or
+> [Upgrade an npm install](#upgrade-an-npm-install) above. If you hit a
+> "two `solo` binaries on PATH" conflict when switching, remove the other
+> install first (see [Switching between Homebrew and npm](#switching-between-homebrew-and-npm)).
+
 ## Switching between Homebrew and npm
 
 If you want to switch package managers (for example, from an older npm install
@@ -100,6 +134,6 @@ Confirm the reinstall:
 solo --version
 ```
 
-For additional cleanup options (removing Solo-managed Kind clusters and other
-artifacts), see
-[Troubleshooting Installation](/docs/simple-solo-setup/system-readiness#troubleshooting-installation).
+For additional cleanup options - removing a legacy npm install, Solo-managed
+Kind clusters, and other artifacts - see the
+[Cleanup guide](/docs/simple-solo-setup/cleanup).

--- a/content/en/docs/simple-solo-setup/upgrading-solo.md
+++ b/content/en/docs/simple-solo-setup/upgrading-solo.md
@@ -72,6 +72,12 @@ npm install -g @hiero-ledger/solo@0.76.0
 {{% /tab %}}
 {{< /tabpane >}}
 
+> **Note:** On Solo v0.74.0 and later, a global install - including a pinned
+> version - automatically pre-pulls that version's container images into the
+> [image cache](/docs/advanced-solo-setup/image-cache) (`~/.solo/cache/images/`),
+> which can take a few minutes and several GB on first run. Set
+> `SOLO_NO_CACHE=true` (npm) or `HOMEBREW_NO_SOLO_CACHE` (Homebrew) to skip it.
+
 Confirm the installed version:
 
 ```bash
@@ -106,9 +112,11 @@ If an upgrade leaves Solo in a broken state - for example, conflicts from an
 older install or a partially migrated `~/.solo` - remove Solo and its
 configuration, then reinstall.
 
-> **Warning:** This deletes your Solo home directory (`~/.solo`), including
-> cached configuration and logs. Destroy any running deployments first with
-> `solo one-shot single destroy` - see the
+> **Warning:** This deletes your Solo home directory (`~/.solo`), including the
+> [image cache](/docs/advanced-solo-setup/image-cache), cached configuration,
+> and logs. The reinstall step below re-pulls the image cache (a few minutes,
+> several GB) on Solo v0.74.0 and later. Destroy any running deployments first
+> with `solo one-shot single destroy` - see the
 > [Cleanup guide](/docs/simple-solo-setup/cleanup).
 
 {{< tabpane text=true >}}


### PR DESCRIPTION
**Description**:
Address #161: document installing a specific (non-latest) Solo version via Homebrew formula or npm.

Also consolidate the upgrade/cleanup docs to remove duplication:
- **upgrading-solo**: rename title to "Upgrading an existing Solo installation"
- **cleanup**: add the "Clean up legacy npm installations" section (canonical home); fix the weight collision (5 -> 6).
- **system-readiness:** replace the duplicated "Troubleshooting Installation" cleanup/reset blocks with cross-references to the Cleanup and Upgrading guides.

**Related issue(s)**:

Fixes #161 

**Notes for reviewer**:
tested the installation of a specific (non-latest) Solo version via Homebrew formula on MacOS.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
