### PR TITLE
docs: use solo commands for port/deployment lookups; standardize "Expected output"

### DIFF
--- a/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/manual-deployment.md
@@ -39,7 +39,7 @@ Before proceeding, ensure you have completed the following:
 
 ## Deployment Steps
 
-> **Note:** The example output blocks below are fetched from the latest published Solo release
+> **Note:** The expected output blocks below are fetched from the latest published Solo release
 > at build time and will always reflect the current version.
 
 ### 1. Connect Cluster and Create Deployment
@@ -107,7 +107,7 @@ Before proceeding, ensure you have completed the following:
 
   PEM key files are written to `~/.solo/cache/keys/`.
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-keys-consensus-generate" lang="bash" >}}
 
@@ -122,7 +122,7 @@ into the cluster setup namespace:
   solo cluster-ref config setup --cluster-setup-namespace "${SOLO_CLUSTER_SETUP_NAMESPACE}"
   ```
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-cluster-ref-config-setup" lang="bash" >}}
 
@@ -137,7 +137,7 @@ HAProxy, Envoy, and MinIO:
   solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}"
   ```
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-consensus-network-deploy" lang="bash" >}}
 
@@ -155,7 +155,7 @@ HAProxy, Envoy, and MinIO:
     --release-tag "${CONSENSUS_NODE_VERSION}"
   ```
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-consensus-node-setup" lang="bash" >}}
 
@@ -169,7 +169,7 @@ HAProxy, Envoy, and MinIO:
   solo consensus node start --deployment "${SOLO_DEPLOYMENT}"
   ```
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-consensus-node-start" lang="bash" >}}
 
@@ -192,7 +192,7 @@ REST API and gRPC endpoint:
 submitting record files. The `--enable-ingress` flag installs the HAProxy
 ingress controller for the mirror node REST API.
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-mirror-node-add" lang="bash" >}}
 
@@ -208,7 +208,7 @@ ingress controller for the mirror node REST API.
     --cluster-ref kind-${SOLO_CLUSTER_NAME}
   ```
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-explorer-node-add" lang="bash" >}}
 
@@ -226,7 +226,7 @@ endpoint for EVM tooling (MetaMask, Hardhat, Foundry, etc.):
   ```
 > TODO: double check these, and update in solo repo if needed to match, also double check the exported variables match
 
-- **Example output**:
+- **Expected output**:
 
   {{< solo-output ref="solo-relay-node-add" lang="bash" >}}
 

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -288,10 +288,10 @@ Adjust these in **Docker Desktop → Settings → Resources** and restart Docker
 Most management commands (stop, start, diagnostics) require the deployment name. Retrieve it with:
 
 ```bash
-cat ~/.solo/cache/last-one-shot-deployment.txt
+solo one-shot show deployment
 ```
 
-This outputs your deployment name — defaults to `one-shot` for one-shot deployments, or the value you passed to `--deployment`. Use it as `<deployment-name>` in subsequent commands.
+This prints your deployment details, including the deployment name — it defaults to `one-shot` for one-shot deployments, or the value you passed to `--deployment`. Use it as `<deployment-name>` in subsequent commands. See [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name) for more detail.
 
 ### 10. How do I create test accounts after deployment?
 

--- a/content/en/docs/simple-solo-setup/managing-your-network.md
+++ b/content/en/docs/simple-solo-setup/managing-your-network.md
@@ -28,19 +28,7 @@ Before proceeding, ensure you have completed the following:
 
 ## Find Your Deployment Name
 
-Most management commands require your deployment name. Run the following command to retrieve it:
-
-  ```bash
-  cat ~/.solo/cache/last-one-shot-deployment.txt
-  ```
-
-Expected output — the deployment name you passed to `solo one-shot single deploy`, or the default `one-shot` if you did not specify `--deployment`:
-
-  ```bash
-  one-shot% 
-  ```
-
-Use the value returned from this command as `<deployment-name>` in all commands on this page.
+Most management commands require your deployment name. Find it with `solo one-shot show deployment` — see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name). It defaults to `one-shot` unless you passed `--deployment`. Use it as `<deployment-name>` in all commands on this page.
 
 ## Stopping and Starting Nodes
 
@@ -109,7 +97,7 @@ To confirm your Hedera network is fully operational, create a test account using
 solo ledger account create --deployment <deployment-name>
 ```
 
-Example output:
+Expected output:
 
 ```bash
  *** new account created ***

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -127,6 +127,8 @@ Retrieve the most recent deployment's name with:
 solo one-shot show deployment
 ```
 
+The output includes a `Deployment Name:` line - use that value as `<deployment-name>` in other commands.
+
 ### Verify the network
 
 After the one-shot deployment completes, verify that the Kubernetes workloads are healthy.
@@ -169,27 +171,50 @@ The ports above are Solo's defaults. Solo uses `kubectl port-forward` to tunnel 
 - If the port is free, Solo logs: `Using requested port <port>`.
 - If the port is already occupied (by another process, or by a previous Solo session that did not clean up its port-forwards), Solo finds the next available port and logs: `Using available port <port>`.
 
-The actual ports used are printed at the end of `solo one-shot single deploy` and saved to a file.
+The actual ports used are printed at the end of `solo one-shot single deploy`. You can also look them up at any time with the Solo CLI, using your deployment name (see [Capture your deployment name](#capture-your-deployment-name)).
 
-> **Note:** The commands below use `$(cat ~/.solo/cache/last-one-shot-deployment.txt)` to look up the deployment name automatically. This cache file is **only created by `solo one-shot` commands**. If you deployed using individual CLI commands, this file does not exist - find your deployment name with `solo deployment config list` instead, then substitute it in place of the `$(cat ...)` subshell.
+To view the active port assignments:
 
-To see the active port assignments:
+```bash
+solo deployment config ports --deployment <deployment-name>
+```
 
-  ```bash
-  cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards
-  ```
+{{< details summary="Expected output" >}}
 
-To check deployment info including port assignments:
+```text
+=== Port-forwards for deployment: one-shot ===
+Cluster: one-shot
+Namespace: one-shot
 
-  ```bash
-  solo deployment config info --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
-  ```
+ *** Consensus node gRPC ***
+-------------------------------------------------------------------------------
+ - component 1: localhost:35211 -> pod:50211
+
+ *** Mirror node REST ***
+-------------------------------------------------------------------------------
+ - component 1: localhost:38081 -> pod:80
+
+ *** JSON-RPC relay ***
+-------------------------------------------------------------------------------
+ - component 1: localhost:37546 -> pod:7546
+
+ *** Explorer ***
+-------------------------------------------------------------------------------
+ - component 1: localhost:38080 -> pod:8080
+```
+
+{{< /details >}}
+
+This prints each component's local port and the pod port it forwards to. Related commands:
+
+- `solo deployment config info --deployment <deployment-name>` - port assignments **plus** running status and component versions.
+- `solo deployment diagnostics connections --deployment <deployment-name>` - actively tests that each port responds (runs an end-to-end connectivity check, and creates a temporary test account).
 
 To restore port-forwards after a system restart without redeploying:
 
-  ```bash
-  solo deployment refresh port-forwards --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
-  ```
+```bash
+solo deployment refresh port-forwards --deployment <deployment-name>
+```
 
 ### Endpoints for Solo 0.62 and earlier
 

--- a/content/en/docs/simple-solo-setup/upgrade-your-network.md
+++ b/content/en/docs/simple-solo-setup/upgrade-your-network.md
@@ -25,19 +25,7 @@ Before upgrading, ensure you have completed the following:
 
 ## Find your deployment name
 
-If you used the default deployment name, it is `one-shot`. Otherwise, find the current deployment name with one of these commands:
-
-```bash
-cat ~/.solo/cache/last-one-shot-deployment.txt
-```
-
-or:
-
-```bash
-solo deployment config info --deployment <deployment-name>
-```
-
-Use the value returned from these commands as `<deployment-name>` in the upgrade command.
+The default for one-shot deployments is `one-shot`. If you used a different name, find it with `solo one-shot show deployment` (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)). Use that value as `<deployment-name>` in the upgrade command.
 
 ## Upgrade the network
 

--- a/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
+++ b/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
@@ -34,11 +34,7 @@ Before proceeding, ensure you have completed the following:
   local environment meets all hardware and software requirements, including Docker and Solo.
 - [**Quickstart**](/docs/simple-solo-setup/quickstart/) - you have a running Solo
   network deployed using `solo one-shot single deploy`.
-- To find your deployment name at any time, run:
-
-  ```bash
-  cat ~/.solo/cache/last-one-shot-deployment.txt
-  ```
+- To find your deployment name at any time, run `solo one-shot show deployment` (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)).
 
 ---
 
@@ -204,15 +200,7 @@ In most cases you should use `localhost:38081` (Solo 0.63+) or `localhost:8081` 
 
 ## Port Reference
 
-The ports listed below are Solo's **default** targets. Solo checks each port before opening a tunnel — if the port is already in use, Solo picks the next available one and logs `Using available port <port>`. If an endpoint is not reachable, check the actual ports used by your deployment:
-
-```bash
-# View the saved port-forward assignments
-cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards
-
-# Or query deployment info directly
-solo deployment config info --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
-```
+The ports listed below are Solo's **default** targets. Solo checks each port before opening a tunnel - if the port is already in use, Solo picks the next available one and logs `Using available port <port>`. If an endpoint is not reachable, check the actual ports your deployment is using with `solo deployment config ports --deployment <deployment-name>` - see [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for the full set of commands.
 
 The default local ports depend on your Solo version:
 

--- a/content/en/docs/using-solo/using-network-load-generator-with-solo.md
+++ b/content/en/docs/using-solo/using-network-load-generator-with-solo.md
@@ -37,11 +37,7 @@ begin a load test against your deployment.
   --test CryptoTransferLoadTest
  ```
 
-Replace `<deployment-name>` with your deployment name. You can find it by running:
-
-```bash
-cat ~/.solo/cache/last-one-shot-deployment.txt
-```
+Replace `<deployment-name>` with your deployment name - find it with `solo one-shot show deployment` (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)).
 
 The `--args` flag passes arguments directly to the NLG. In this example:
 

--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -84,11 +84,7 @@ These accounts and their private keys are saved to a cache directory on completi
 > Note: ED25519 accounts are not compatible with Hardhat, ethers.js, or MetaMask when used via the JSON-RPC interface.
 > Always use the ECDSA keys from accounts.json for EVM tooling.
 
-- To find your deployment name, run:
-
-  ```bash
-  cat ~/.solo/cache/last-one-shot-deployment.txt
-  ```
+- To find your deployment name, run `solo one-shot show deployment` (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)).
 
 - Then open the accounts file at:
 

--- a/content/en/docs/using-solo/using-solo-with-hiero-sdks.md
+++ b/content/en/docs/using-solo/using-solo-with-hiero-sdks.md
@@ -141,7 +141,7 @@ examples in this guide.
   cat ~/.solo/one-shot-<your-deployment-name>/accounts.json
   ```
 
-- **Example output:**
+- **Expected output:**
 
   ```json
   {


### PR DESCRIPTION
**Description**:
Replace the janky `cat ~/.solo/one-shot-$(cat .../forwards)` chain and `cat ~/.solo/cache/last-one-shot-deployment.txt` lookups with Solo commands.

**Related issue(s)**:

Fixes #153 

**Notes for reviewer**:
Tested manually and with AI on MacOS against solo@v0.77.0.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)