### PR TITLE
docs: remove broken MetaMask block explorer URL from EVM tools guide (#219)

### DIFF
--- a/content/en/docs/using-solo/using-solo-with-evm-tools.md
+++ b/content/en/docs/using-solo/using-solo-with-evm-tools.md
@@ -381,9 +381,8 @@ To connect MetaMask to your local Solo network:
    | New RPC URL | `http://localhost:37546` |
    | Chain ID | `298` |
    | Currency symbol | `HBAR` |
-   | Block explorer URL | `http://localhost:38080/localnet/dashboard` (optional) |
 
-   > **Note:** If you are using Solo 0.62 or earlier, use `http://localhost:7546` for the RPC URL and `http://localhost:8080/localnet/dashboard` for the block explorer URL.
+   > **Note:** If you are using Solo 0.62 or earlier, use `http://localhost:7546` for the RPC URL.
 
 3. Click **Save** and switch to the **Solo Local** network.
 4. Import an account using an ECDSA private key from `accounts.json`:


### PR DESCRIPTION
**Description**:
Removed the Block explorer URL row from the MetaMask network table, as viewing transactions is covered by Step 6 (search by transaction hash).

**Related issue(s)**:

Fixes #219 

**Notes for reviewer**:
tested locally and confirmed that the previously given instructions gave a page not found error.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
