### PR TITLE
docs: document the ledger system reset command (#113)

### DIFF
--- a/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
+++ b/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
@@ -127,6 +127,25 @@ a fully functional local Hiero network, including:
         solo one-shot single deploy | tee solo-deploy.log
   ```
 
+## Resetting Between Tests
+
+If several tests each need a clean genesis ledger, you do not have to redeploy
+for each one. After deploying once, reset the ledger to genesis between tests to
+return to a known starting state without recreating the cluster:
+
+  ```yaml
+    - name: Reset ledger to genesis
+      env:
+        SOLO_DEPLOYMENT: solo-deployment
+      run: |
+        set -euo pipefail
+        solo ledger system reset --deployment "${SOLO_DEPLOYMENT}"
+  ```
+
+This is faster than a destroy-and-redeploy cycle. See
+[Reset the ledger to genesis](/docs/simple-solo-setup/managing-your-network#reset-the-ledger-to-genesis)
+for details and available flags.
+
 ## Cleanup
 
 After the workflow completes, destroy the Solo deployment and delete the Kind

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -323,3 +323,10 @@ The mirror node accumulates transaction history while the network is running. If
     ```
 
 - Then run `k9s` to launch. It is especially helpful for watching pod startup progress during deployment.
+
+### 14. How do I reset the ledger to a clean genesis state without redeploying?
+
+Run `solo ledger system reset --deployment <deployment-name>` to reset the
+ledger to genesis - clearing saved state and ledger-related secrets - while
+keeping the same cluster and deployment. See
+[Reset the ledger to genesis](/docs/simple-solo-setup/managing-your-network#reset-the-ledger-to-genesis).

--- a/content/en/docs/simple-solo-setup/managing-your-network.md
+++ b/content/en/docs/simple-solo-setup/managing-your-network.md
@@ -138,6 +138,33 @@ This confirms that:
 * The mirror node is indexing transactions
 * The explorer is displaying data properly
 
+## Reset the ledger to genesis
+
+To return a running deployment to a clean genesis state without tearing it down
+and redeploying, reset the ledger system. This clears the saved consensus state
+and ledger-related secrets, returning the ledger to genesis - with no accounts,
+files, or balances beyond the genesis defaults:
+
+```bash
+solo ledger system reset --deployment <deployment-name>
+```
+
+`solo ledger system reset` is the counterpart to `solo ledger system init`
+(which initializes a new deployment). Use it when you want a fresh ledger - for
+example, to rerun a scenario from a known starting point - while keeping the
+same Kind cluster and deployment.
+
+| Flag | Description |
+| --- | --- |
+| `--deployment` | The deployment to reset. |
+| `--node-aliases` | Comma-separated consensus node aliases to reset. Defaults to all nodes in the deployment. |
+| `--cluster-ref` | The cluster reference, for a deployment that spans multiple clusters. |
+
+> **Note:** This discards on-ledger state created since genesis and cannot be
+> undone. It does not delete the cluster or deployment - to remove those
+> entirely, use `solo one-shot single destroy` (see the
+> [Cleanup guide](/docs/simple-solo-setup/cleanup)).
+
 ## Viewing Logs
 
 To capture logs and diagnostic information for your deployment:


### PR DESCRIPTION
**Description**:
Add usage for 'solo ledger system reset', which resets the ledger to genesis by clearing saved consensus state and ledger-related secrets:


**Related issue(s)**:

Fixes #113 

**Notes for reviewer**:
Verified against Solo v0.78.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
