### PR TITLE
docs: add Remove the Kind cluster step to Cleanup (#218)

### DIFF
--- a/content/en/docs/simple-solo-setup/cleanup.md
+++ b/content/en/docs/simple-solo-setup/cleanup.md
@@ -53,6 +53,20 @@ If `solo one-shot single destroy` fails part-way through (for example, due to an
 
 If rerunning destroy does not release the resources, use the **Full Reset** procedure below to force a clean state.
 
+### Remove the Kind cluster
+
+`solo one-shot single destroy` intentionally leaves the Kind cluster in Docker
+so you can redeploy quickly. If you want a completely clean slate, delete the
+cluster after destroying the deployment:
+
+```bash
+kind delete cluster --name solo-cluster
+```
+
+`solo-cluster` is Solo's default Kind cluster name; run `kind get clusters` to
+confirm yours if you used a custom name. To also remove Solo's local
+configuration and cache, use the [Full Reset](#full-reset) procedure.
+
 ## Resource Usage
 
 Solo deploys a fully functioning mirror node that stores the transaction history


### PR DESCRIPTION
**Description**:
Teardown (solo one-shot single destroy or kubectl delete ns) leaves the Kind cluster running in Docker, which is easy to miss. Added a 'Remove the Kind cluster' section documenting 'kind delete cluster --name solo-cluster' as an optional clean-slate step under normal teardown, with a pointer to Full Reset for also wiping ~/.solo.

**Related issue(s)**:

Fixes #218 

**Notes for reviewer**:
Verified against Solo v0.78.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
