### PR TITLE
docs: clarify which dependencies are auto-provisioned vs user-installed (#217)

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -41,13 +41,13 @@ Install the latest Solo CLI globally using one of the following methods:
   brew install hiero-ledger/tools/solo
   ```
 
-- **npm** (alternative installation method):
+- **npm** (required for native Windows PowerShell; alternative on macOS/Linux/WSL2):
 
   ```bash
   npm install -g @hiero-ledger/solo@latest
   ```
 
-  > **Note:** npm installation is an alternative to Homebrew. The Homebrew tap is the recommended installation method because it installs Node.js for you (npm installs require Node.js already present) and may have more up-to-date releases. Either way, Solo provisions kubectl, Helm, and Kind automatically at deploy time.
+  > **Note:** On macOS, Linux, and WSL2, Homebrew is recommended — it installs Node.js for you, whereas npm requires Node.js to already be present. On native Windows (PowerShell), npm is the only available option. Regardless of installation method, Solo provisions kubectl, Helm, and Kind automatically at deploy time.
 
 ### Verify the installation
 

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -47,7 +47,7 @@ Install the latest Solo CLI globally using one of the following methods:
   npm install -g @hiero-ledger/solo@latest
   ```
 
-  > **Note:** npm installation is an alternative to Homebrew. The Homebrew tap is the recommended installation method as it includes kubectl and Helm as dependencies and may have more up-to-date releases.
+  > **Note:** npm installation is an alternative to Homebrew. The Homebrew tap is the recommended installation method because it installs Node.js for you (npm installs require Node.js already present) and may have more up-to-date releases. Either way, Solo provisions kubectl, Helm, and Kind automatically at deploy time.
 
 ### Verify the installation
 

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -28,31 +28,34 @@ Solo's resource requirements depend on your deployment size:
 
 ## Software Requirements
 
-Solo manages most of its own dependencies depending on how you install it:
+Solo sets up most of the tools it needs for you. The table below shows what each
+install method provides, what Solo provisions automatically, and what you must
+install yourself.
 
-- **Homebrew install** (`brew install hiero-ledger/tools/solo`) - automatically installs Node.js and Solo, plus kubectl and Helm as dependencies.
-- **`one-shot` commands** — automatically install **Kind** and **Podman** (if Docker is not found). **kubectl and Helm are not auto-installed** and must be pre-installed.
+| Tool | Required version | How it is installed |
+| --- | --- | --- |
+| [Solo](https://github.com/hiero-ledger/solo) | latest | `brew install hiero-ledger/tools/solo`, or `npm install -g @hiero-ledger/solo` |
+| [Node.js](https://nodejs.org/en/download) | >= 22.0.0 (lts/jod) | **Homebrew installs it for you**; with **npm you install it yourself** |
+| Container runtime ([Docker](https://www.docker.com/products/docker-desktop) / [Podman](https://podman.io)) | See [Docker](#docker) below | **You install it** - Docker Desktop (macOS/Windows) or Docker Engine/Podman (Linux). Solo cannot install one. |
+| [kubectl](https://kubernetes.io/docs/reference/kubectl/) | >= v1.32.2 | **Solo provisions it** at deploy time - reuses a compatible copy already on your system, or downloads one into `~/.solo/bin` |
+| [Helm](https://helm.sh) | v3.14.2 | **Solo provisions it** at deploy time |
+| [Kind](https://kind.sigs.k8s.io) | >= v0.29.0 | **Solo provisions it** at deploy time |
+| [Kubernetes](https://kubernetes.io) | >= v1.32.2 | Installed automatically by Kind |
+| [k9s](https://k9scli.io/topics/install/) (optional) | >= v0.27.4 | You install it |
 
-### Pre-installation Requirements
+> **Note:** Solo's provisioned copies of kubectl and Helm live in `~/.solo/bin`,
+> which is not necessarily on your `PATH`. If you want to run `kubectl` or `helm`
+> commands yourself (some guides do), install [kubectl](https://kubernetes.io/docs/tasks/tools/)
+> and [Helm](https://helm.sh/docs/intro/install/) on your `PATH` separately.
 
-Before running `solo one-shot single deploy`, you **must** have:
-- A **container runtime**: either [Docker Desktop](https://www.docker.com/products/docker-desktop) (macOS/Windows) or Docker Engine/Podman (Linux). Solo cannot install a container runtime.
-- **kubectl** and **Helm**: Solo requires these pre-installed. The `one-shot` command checks for their presence but does not install them.
-  - **Homebrew users**: These are installed automatically as dependencies of the `solo` formula.
-  - **npm install users** (Linux, WSL2, or native Windows): Install kubectl and Helm manually before running Solo.
-- **Windows (WSL2) users**: WSL2 requires hardware virtualization and the Virtual Machine Platform Windows feature. Follow Microsoft's [Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) guide to install WSL and meet these prerequisites. If you cannot enable virtualization (for example, `wsl --install` reports `HCS_E_HYPERV_NOT_INSTALLED`), use the native **Windows (PowerShell)** path instead, which does not require WSL2.
+### Windows (WSL2) prerequisite
 
-> **Important:** The `one-shot` deployment will fail immediately if kubectl or Helm are missing, even on macOS/Windows where Homebrew typically installs them as dependencies.
-
-| Tool           | Required Version         | Where to get it                                                                   |
-|----------------|--------------------------|-----------------------------------------------------------------------------------|
-| Node.js        | >= 22.0.0 (lts/jod)      | [nodejs.org](https://nodejs.org/en/download)                                      |
-| Kind           | >= v0.29.0               | [kind.sigs.k8s.io](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)  |
-| Kubernetes     | >= v1.32.2               | Installed automatically by Kind                                                   |
-| Kubectl        | >= v1.32.2               | [kubernetes.io](https://kubernetes.io/docs/tasks/tools/)                          |
-| Helm           | v3.14.2                  | [helm.sh](https://helm.sh/docs/intro/install/)                                    |
-| Docker         | See Docker section below | [docker.com](https://www.docker.com/products/docker-desktop)                      |
-| k9s (optional) | >= v0.27.4               | [k9scli.io](https://k9scli.io/topics/install/)                                    |
+If you install Solo on Windows via WSL2, WSL2 requires hardware virtualization
+and the Virtual Machine Platform Windows feature. Follow Microsoft's
+[Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) guide to
+install WSL and meet these prerequisites. If you cannot enable virtualization
+(for example, `wsl --install` reports `HCS_E_HYPERV_NOT_INSTALLED`), use the
+native **Windows (PowerShell)** path instead, which does not require WSL2.
 
 ## Docker
 
@@ -109,7 +112,7 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 
     > **macOS prerequisite:** Docker Desktop must be open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin.
 
-3. Install Solo (this installs all other dependencies automatically):
+3. Install Solo:
 
     ```sh
     brew install hiero-ledger/tools/solo
@@ -150,23 +153,13 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 
     Log out and back in for the group changes to take effect.
 
-3. Install kubectl:
-
-    ```sh
-    sudo apt update && sudo apt install -y ca-certificates curl
-    ARCH="$(dpkg --print-architecture)"
-    curl -fsSLo kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/kubectl
-    ```
-
-4. Install Solo (this installs all other dependencies automatically):
+3. Install Solo:
 
     ```sh
     brew install hiero-ledger/tools/solo
     ```
 
-5. Verify the installation:
+4. Verify the installation:
 
     ```sh
     solo --version
@@ -192,24 +185,15 @@ Run Solo natively from **Windows PowerShell**. Run every command below in a Powe
 
     Or download the installer from [nodejs.org](https://nodejs.org/en/download).
 
-3. Install kubectl and Helm (Solo does not auto-install these):
-
-    ```powershell
-    winget install Kubernetes.kubectl
-    winget install Helm.Helm
-    ```
-
-    Or download them from the [kubectl](https://kubernetes.io/docs/tasks/tools/) and [Helm](https://helm.sh/docs/intro/install/) release pages.
-
-4. Install Solo via npm. 
+3. Install Solo via npm. 
     
-    npm installs the Solo CLI only - kubectl and Helm were installed in step 3, and `one-shot` auto-installs Kind and Podman:
+    npm installs the Solo CLI only; Solo provisions kubectl, Helm, and Kind automatically at deploy time:
 
     ```powershell
     npm install -g @hiero-ledger/solo@latest
     ```
 
-1. Verify the installation:
+4. Verify the installation:
 
     ```powershell
     solo --version
@@ -221,8 +205,8 @@ Run Solo natively from **Windows PowerShell**. Run every command below in a Powe
 
 {{% tab header="Windows (WSL2)" lang="wsl2" %}}
 
-> **Note:** Make sure your machine meets the WSL2 prerequisites in
-> [Pre-installation Requirements](#pre-installation-requirements) first. If WSL
+> **Note:** Make sure your machine meets the
+> [Windows (WSL2) prerequisite](#windows-wsl2-prerequisite) first. If WSL
 > and a Linux distribution are already installed, skip step 1 (and you may use a
 > distribution other than Ubuntu).
 
@@ -250,23 +234,13 @@ Run Solo natively from **Windows PowerShell**. Run every command below in a Powe
     - Enable WSL2 integration: Docker Desktop > Settings > Resources > WSL Integration.
     - Allocate at least 12 GB of memory: Docker Desktop > Settings > Resources > Memory.
 
-4. Install kubectl:
-
-    ```sh
-    sudo apt update && sudo apt install -y ca-certificates curl
-    ARCH="$(dpkg --print-architecture)"
-    curl -fsSLo kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl"
-    chmod +x kubectl
-    sudo mv kubectl /usr/local/bin/kubectl
-    ```
-
-5. Install Solo (this installs all other dependencies automatically):
+4. Install Solo:
 
     ```sh
     brew install hiero-ledger/tools/solo
     ```
 
-6. Verify the installation:
+5. Verify the installation:
 
     ```sh
     solo --version

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -36,26 +36,33 @@ install yourself.
 | --- | --- | --- |
 | [Solo](https://github.com/hiero-ledger/solo) | latest | `brew install hiero-ledger/tools/solo`, or `npm install -g @hiero-ledger/solo` |
 | [Node.js](https://nodejs.org/en/download) | >= 22.0.0 (lts/jod) | **Homebrew installs it for you**; with **npm you install it yourself** |
-| Container runtime ([Docker](https://www.docker.com/products/docker-desktop) / [Podman](https://podman.io)) | See [Docker](#docker) below | **You install it** - Docker Desktop (macOS/Windows) or Docker Engine/Podman (Linux). Solo cannot install one. |
+| Container runtime ([Docker](https://www.docker.com/products/docker-desktop) / [Podman](https://podman.io)) | See [Docker](#docker) below | **You install it** — Docker Desktop (macOS/Windows) or Docker Engine (Linux). Solo auto-installs Podman on Linux/macOS/WSL2 if Docker Engine is not found. Not supported on native Windows. |
 | [kubectl](https://kubernetes.io/docs/reference/kubectl/) | >= v1.32.2 | **Solo provisions it** at deploy time - reuses a compatible copy already on your system, or downloads one into `~/.solo/bin` |
 | [Helm](https://helm.sh) | v3.14.2 | **Solo provisions it** at deploy time |
 | [Kind](https://kind.sigs.k8s.io) | >= v0.29.0 | **Solo provisions it** at deploy time |
 | [Kubernetes](https://kubernetes.io) | >= v1.32.2 | Installed automatically by Kind |
 | [k9s](https://k9scli.io/topics/install/) (optional) | >= v0.27.4 | You install it |
 
-> **Note:** Solo's provisioned copies of kubectl and Helm live in `~/.solo/bin`,
-> which is not necessarily on your `PATH`. If you want to run `kubectl` or `helm`
-> commands yourself (some guides do), install [kubectl](https://kubernetes.io/docs/tasks/tools/)
-> and [Helm](https://helm.sh/docs/intro/install/) on your `PATH` separately.
+> **Note:** Solo's provisioned copies of kubectl, Kind, and Helm live in `~/.solo/bin`,
+> which is not necessarily on your `PATH`. If you want to run `kubectl`, `kind`, or `helm`
+> commands yourself (some guides do), install [kubectl](https://kubernetes.io/docs/tasks/tools/),
+> [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), and
+> [Helm](https://helm.sh/docs/intro/install/) on your `PATH` separately.
 
 ### Windows (WSL2) prerequisite
 
-If you install Solo on Windows via WSL2, WSL2 requires hardware virtualization
-and the Virtual Machine Platform Windows feature. Follow Microsoft's
-[Install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) guide to
-install WSL and meet these prerequisites. If you cannot enable virtualization
-(for example, `wsl --install` reports `HCS_E_HYPERV_NOT_INSTALLED`), use the
-native **Windows (PowerShell)** path instead, which does not require WSL2.
+Kind (which Solo provisions automatically) requires WSL2 to be enabled on
+Windows, but you do not need a WSL2 Linux distro installed — only the WSL2
+feature itself. Enable it with:
+
+```powershell
+wsl --install --no-distribution
+```
+
+WSL2 requires hardware virtualization and the Virtual Machine Platform Windows
+feature. If virtualization is unavailable (for example, `wsl --install` reports
+`HCS_E_HYPERV_NOT_INSTALLED`), use the native **Windows (PowerShell)** path
+instead, which does not require WSL2.
 
 ## Docker
 

--- a/content/en/docs/simple-solo-setup/upgrading-solo.md
+++ b/content/en/docs/simple-solo-setup/upgrading-solo.md
@@ -32,7 +32,7 @@ brew upgrade hiero-ledger/tools/solo
 ```
 
 `brew update` refreshes Homebrew's formulae; `brew upgrade` then installs the
-latest Solo and refreshes its `kubectl` and `Helm` dependencies. Verify the new
+latest Solo (and Node.js, its only Homebrew dependency). Verify the new
 version:
 
 ```bash
@@ -48,8 +48,10 @@ tag to move to the newest release:
 npm install -g @hiero-ledger/solo@latest
 ```
 
-> **Note:** Unlike the Homebrew formula, npm does not install `kubectl` and
-> `Helm`. After a major-version upgrade, re-check the required tool versions in
+> **Note:** Unlike the Homebrew formula, npm does not install Node.js - make
+> sure Node.js is present before upgrading. (Solo provisions kubectl, Helm, and
+> Kind automatically at deploy time regardless of install method.) After a
+> major-version upgrade, re-check the required tool versions in
 > [System Readiness](/docs/simple-solo-setup/system-readiness).
 
 ## Install a specific version


### PR DESCRIPTION
**Description**:
The docs contradicted themselves: kubectl/Helm were listed as manual prerequisites while also said to be installed by 'brew install solo'. Neither is correct. So rewrote the Software Requirements.

**Related issue(s)**:

Fixes #217 

**Notes for reviewer**:
Verified against Solo v0.78.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
