### PR TITLE
docs: add hiero-solo-action CI guide and cross-links (#175)

### DIFF
--- a/content/en/docs/advanced-solo-setup/Deploy-Solo-on-a-GitHub-hosted-runner.md
+++ b/content/en/docs/advanced-solo-setup/Deploy-Solo-on-a-GitHub-hosted-runner.md
@@ -15,6 +15,9 @@ GitHub-hosted runner and the Solo CLI installed via Homebrew.
 For the hardware specs that runner provides, see
 [GitHub's documentation on standard hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
 
+> **Note:** For a simpler path where dependency installation is handled automatically,
+> see [Using hiero-solo-action](/docs/advanced-solo-setup/using-hiero-solo-action).
+
 ---
 
 ## How It Works

--- a/content/en/docs/advanced-solo-setup/image-cache.md
+++ b/content/en/docs/advanced-solo-setup/image-cache.md
@@ -1,6 +1,6 @@
 ---
 title: "Solo Image Cache"
-weight: 7
+weight: 8
 description: >
   Speed up deployments by pre-pulling and reusing the container images Solo
   needs. Manage the local image cache with the solo cache image commands, and

--- a/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
+++ b/content/en/docs/advanced-solo-setup/solo-ci-workflow.md
@@ -17,6 +17,9 @@ covering runner requirements, tool installation, and automated network deploymen
 Each step installs dependencies directly in the workflow, since CI runners are
 fresh environments with no pre-installed tools.
 
+> **Note:** For a simpler path where dependency installation is handled automatically,
+> see [Using hiero-solo-action](/docs/advanced-solo-setup/using-hiero-solo-action).
+
 ## Prerequisites
 
 Before proceeding, ensure you have completed the following:

--- a/content/en/docs/advanced-solo-setup/using-hiero-solo-action.md
+++ b/content/en/docs/advanced-solo-setup/using-hiero-solo-action.md
@@ -1,0 +1,117 @@
+---
+title: "Using hiero-solo-action in CI"
+weight: 7
+description: >
+  Use the hiero-solo-action composite action to spin up a temporary Solo network
+  in GitHub Actions without managing Kind, Helm, or Solo CLI installation yourself.
+categories: ["Advanced"]
+tags: ["advanced", "developer", "ci-cd", "testing"]
+type: docs
+---
+
+## Overview
+
+The [hiero-solo-action](https://github.com/hiero-ledger/hiero-solo-action) composite action
+deploys a Solo network inside a GitHub Actions job. It installs all required dependencies —
+Kind, Helm, Node.js, Java, and Python — and creates a funded account whose keys are
+available as step outputs.
+
+## Runner Requirements
+
+The action requires a **Linux runner** (`ubuntu-latest` or equivalent). All dependencies are
+installed by the action itself; no pre-installed tools are required on the runner. For hardware
+sizing guidance, see [Runner Requirements](/docs/advanced-solo-setup/solo-ci-workflow#runner-requirements).
+
+## Minimal Example
+
+```yaml
+- name: Setup Solo Network
+  uses: hiero-ledger/hiero-solo-action@<VERSION>
+  id: solo
+  with:
+    soloVersion: "0.78.0"
+
+- name: Run Tests
+  env:
+    ACCOUNT_ID: ${{ steps.solo.outputs.accountId }}
+    PUBLIC_KEY: ${{ steps.solo.outputs.publicKey }}
+    PRIVATE_KEY: ${{ steps.solo.outputs.privateKey }}
+  run: |
+    echo "Account ID: $ACCOUNT_ID"
+    echo "Public Key: $PUBLIC_KEY"
+    echo "Private Key: $PRIVATE_KEY"
+    # Connect your SDK to localhost:35211 using ACCOUNT_ID and PRIVATE_KEY
+```
+
+**Expected Output:**
+
+```yaml
+Account ID: 0.0.1002
+Public Key: 302a300506032b6570032100104651be92e4d234acdfbe05e5b2d74982868fc9698f4be49a71c9787a419cbd
+Private Key: 302e020100300506032b6570042204209111894988a58ed7ab38bde01c4ea37a59ffd59dedb6726fe230021ad4199fdc
+```
+
+> **Note:** Replace `<VERSION>` with the latest tag from
+> [hiero-solo-action releases](https://github.com/hiero-ledger/hiero-solo-action/releases).
+> The action's default `soloVersion` lags behind the latest Solo release — set it explicitly to
+> the version you are testing against. The exact `Account ID` varies per deployment. Keys are
+> DER-encoded hex strings (ED25519 private key begins with `302e`, public key with `302a`).
+
+## Common Configurations
+
+### With Mirror Node
+
+```yaml
+- name: Setup Solo Network
+  uses: hiero-ledger/hiero-solo-action@<VERSION>
+  id: solo
+  with:
+    soloVersion: "0.78.0"
+    installMirrorNode: true
+```
+
+The mirror node REST API is available at `localhost:38081`.
+
+### With JSON-RPC Relay
+
+Setting `installRelay: true` automatically deploys a mirror node alongside the relay (the relay requires one).
+
+```yaml
+- name: Setup Solo Network
+  uses: hiero-ledger/hiero-solo-action@<VERSION>
+  id: solo
+  with:
+    soloVersion: "0.78.0"
+    installRelay: true
+```
+
+The JSON-RPC Relay is available at `localhost:37546`. The mirror node REST API is also available at `localhost:38081`.
+
+### With Dual Mode (Two Consensus Nodes)
+
+```yaml
+- name: Setup Solo Network
+  uses: hiero-ledger/hiero-solo-action@<VERSION>
+  id: solo
+  with:
+    soloVersion: "0.78.0"
+    dualMode: true
+```
+
+Node 1 is accessible at `localhost:35211`; node 2 at `localhost:36211`.
+
+## Outputs
+
+The action creates one ED25519 account and one ECDSA account, and exposes their keys as step outputs.
+
+| Output | Key type | Description |
+|---|---|---|
+| `accountId`, `publicKey`, `privateKey` | ED25519 | Default account (shorthand aliases) |
+| `ed25519AccountId`, `ed25519PublicKey`, `ed25519PrivateKey` | ED25519 | Same account, explicit names |
+| `ecdsaAccountId`, `ecdsaPublicKey`, `ecdsaPrivateKey` | ECDSA | ECDSA account |
+| `deployment` | — | Always `"solo-deployment"` |
+
+## Full Input Reference
+
+For the complete list of inputs, port overrides, and version alignment notes, see the
+[hiero-solo-action README](https://github.com/hiero-ledger/hiero-solo-action#inputs).


### PR DESCRIPTION
**Description**:
Add a new Advanced Setup page documenting the hiero-solo-action composite action as a simpler CI path alongside the existing manual CLI guides.

**Related issue(s)**:

Fixes #175 

**Notes for reviewer**:
Claude AI testing against Solo V0.78.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
