### PR TITLE
docs: add Docker Desktop File Sharing requirement for macOS Homebrew installs (#212)

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -24,7 +24,9 @@ Before you begin, ensure you have completed the following:
 - System Readiness:
   - Prepare your local environment (Docker, Kind, Kubernetes, and related tooling) by following the **[System Readiness](/docs/simple-solo-setup/system-readiness)** guide.
 
-> **macOS prerequisite:** Docker Desktop must be installed and open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin. On **Apple Silicon Macs** (M1/M2/M3/M4), also add `/opt/homebrew` to Docker Desktop's File Sharing list (**Settings → Resources → File Sharing**) — without it, the deploy fails with a "mounts denied" error. See [System Readiness](/docs/simple-solo-setup/system-readiness#platform-setup) for the full setup step.
+> **macOS prerequisite:** Docker Desktop must be installed and open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin.
+
+> **Apple Silicon:** If `solo one-shot single deploy` fails with a **"mounts denied"** error, see [Troubleshooting Installation](/docs/simple-solo-setup/system-readiness#troubleshooting-installation).
 
 > **Windows (PowerShell):** Complete the [System Readiness](/docs/simple-solo-setup/system-readiness) **Windows** tab first, then run the commands on this page from a PowerShell terminal. The `solo` and `kubectl` commands are identical in PowerShell; only shell-specific commands (pipes, port checks, and `~/.solo` paths) differ, and those show a **PowerShell** tab.
 

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -24,7 +24,7 @@ Before you begin, ensure you have completed the following:
 - System Readiness:
   - Prepare your local environment (Docker, Kind, Kubernetes, and related tooling) by following the **[System Readiness](/docs/simple-solo-setup/system-readiness)** guide.
 
-> **macOS prerequisite:** Docker Desktop must be installed and open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin.
+> **macOS prerequisite:** Docker Desktop must be installed and open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin. On **Apple Silicon Macs** (M1/M2/M3/M4), also add `/opt/homebrew` to Docker Desktop's File Sharing list (**Settings → Resources → File Sharing**) — without it, the deploy fails with a "mounts denied" error. See [System Readiness](/docs/simple-solo-setup/system-readiness#platform-setup) for the full setup step.
 
 > **Windows (PowerShell):** Complete the [System Readiness](/docs/simple-solo-setup/system-readiness) **Windows** tab first, then run the commands on this page from a PowerShell terminal. The `solo` and `kubectl` commands are identical in PowerShell; only shell-specific commands (pipes, port checks, and `~/.solo` paths) differ, and those show a **PowerShell** tab.
 

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -119,23 +119,13 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 
     > **macOS prerequisite:** Docker Desktop must be open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin.
 
-3. **(Apple Silicon only) Add `/opt/homebrew` to Docker Desktop File Sharing:**
-
-    On Apple Silicon Macs (M1/M2/M3/M4), Homebrew installs to `/opt/homebrew`, which Docker Desktop does not share by default. Without this step, `solo one-shot single deploy` fails immediately with a **"mounts denied"** error.
-
-    - Go to **Docker Desktop → Settings → Resources → File Sharing**.
-    - Click **+** and add `/opt/homebrew`.
-    - Click **Apply & Restart**.
-
-    This is a one-time setting and covers all future Solo version upgrades. Intel Mac users (Homebrew path `/usr/local`) can skip this step.
-
-4. Install Solo:
+3. Install Solo:
 
     ```sh
     brew install hiero-ledger/tools/solo
     ```
 
-5. Verify the installation:
+4. Verify the installation:
 
     ```sh
     solo --version
@@ -304,6 +294,13 @@ with a previous installation - clean up your environment and reinstall:
 - To **upgrade an existing install**, install a **specific version**, or switch
   between Homebrew and npm, see
   [Upgrading an existing Solo installation](/docs/simple-solo-setup/upgrading-solo).
+- **macOS "mounts denied" error on Apple Silicon**: If `solo one-shot single deploy`
+  fails immediately with a **"mounts denied"** or **"path is not shared from the host"**
+  error, add `/opt/homebrew` to Docker Desktop's File Sharing list:
+  **Settings → Resources → File Sharing → +** → add `/opt/homebrew` → **Apply & Restart**.
+  This can occur on Apple Silicon Macs (M1/M2/M3/M4) when Homebrew's install path
+  (`/opt/homebrew`) is not included in Docker Desktop's shared directories.
+  Intel Mac users (Homebrew path `/usr/local`) are not affected.
 - **WSL2 fails to install** (for example, `wsl --install` reports
   `HCS_E_HYPERV_NOT_INSTALLED`): WSL2 requires hardware virtualization and the
   Virtual Machine Platform feature. See Microsoft's

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -119,13 +119,23 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 
     > **macOS prerequisite:** Docker Desktop must be open before running `solo one-shot single deploy`. The Docker daemon is not started automatically on macOS, so confirm Docker Desktop is running from your menu bar before you begin.
 
-3. Install Solo:
+3. **(Apple Silicon only) Add `/opt/homebrew` to Docker Desktop File Sharing:**
+
+    On Apple Silicon Macs (M1/M2/M3/M4), Homebrew installs to `/opt/homebrew`, which Docker Desktop does not share by default. Without this step, `solo one-shot single deploy` fails immediately with a **"mounts denied"** error.
+
+    - Go to **Docker Desktop → Settings → Resources → File Sharing**.
+    - Click **+** and add `/opt/homebrew`.
+    - Click **Apply & Restart**.
+
+    This is a one-time setting and covers all future Solo version upgrades. Intel Mac users (Homebrew path `/usr/local`) can skip this step.
+
+4. Install Solo:
 
     ```sh
     brew install hiero-ledger/tools/solo
     ```
 
-4. Verify the installation:
+5. Verify the installation:
 
     ```sh
     solo --version


### PR DESCRIPTION
**Description**:

- Add the File Sharing setup as a numbered step in the macOS platform setup section of system-readiness.md
- Add a brief callout in quickstart.md macOS prerequisite note for users who go there directly.

**Related issue(s)**:

Fixes #212 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
