### PR TITLE
docs: add nvm EEXIST note to npm upgrade section (#213)

### DIFF
--- a/content/en/docs/simple-solo-setup/upgrading-solo.md
+++ b/content/en/docs/simple-solo-setup/upgrading-solo.md
@@ -54,6 +54,10 @@ npm install -g @hiero-ledger/solo@latest
 > major-version upgrade, re-check the required tool versions in
 > [System Readiness](/docs/simple-solo-setup/system-readiness).
 
+> **nvm users:** If the upgrade fails with `EEXIST: file already exists`, the
+> old binary is still in place. Remove it first, then reinstall - or follow the
+> [Clean reinstall](#clean-reinstall) steps below.
+
 ## Install a specific version
 
 To install a specific (non-latest) Solo release - for example, to reproduce a


### PR DESCRIPTION
**Description**:
Users upgrading Solo under nvm-managed Node may hit EEXIST: file already exists. Add a note pointing them to the clean reinstall section, which already covers this via npm uninstall.

**Related issue(s)**:

Fixes #213 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
