### PR TITLE
docs: deprecate --dev flag

### DIFF
--- a/content/en/docs/advanced-solo-setup/network-deployments/falcon-flags-reference.md
+++ b/content/en/docs/advanced-solo-setup/network-deployments/falcon-flags-reference.md
@@ -96,9 +96,14 @@ Flags passed to `solo consensus node setup`.
 | `--app-config` | string | — | Path to a JSON configuration file for the testing app. |
 | `--admin-public-keys` | string | — | Comma-separated DER-encoded ED25519 public keys in node alias order. |
 | `--domain-names` | string | — | Custom domain name mapping per node alias. |
-| `--dev` | boolean | `false` | Enable developer mode. |
+| `--debug` | boolean | `false` | Enable debug mode. (Formerly `--dev`, which is deprecated — see note below.) |
 | `--quiet-mode` | boolean | `false` | Suppress confirmation prompts. |
 | `--cache-dir` | string | `~/.solo/cache` | Local cache directory for downloaded artifacts. |
+
+> **Deprecated:** The `--dev` flag has been renamed to `--debug`. `--dev` still
+> works as an alias but is deprecated and prints a warning. The `--dev` alias
+> will no longer be supported once Solo `0.82.0` reaches its end of support
+> date.
 
 ---
 
@@ -213,10 +218,15 @@ Flags passed to `solo block node add`.
 | `--image-tag` | string | — | Docker image tag to override the Helm chart default. |
 | `--enable-ingress` | boolean | `false` | Deploy an ingress controller for the block node. |
 | `--domain-name` | string | — | Custom domain name for the block node. |
-| `--dev` | boolean | `false` | Enable developer mode for the block node. |
+| `--debug` | boolean | `false` | Enable debug mode for the block node. (Formerly `--dev`, which is deprecated — see note below.) |
 | `--block-node-chart-dir` | string | — | Path to a local Hiero block node Helm chart directory. |
 | `--quiet-mode` | boolean | `false` | Suppress confirmation prompts. |
 | `--values-file` | string | — | Comma-separated Helm chart values file paths for the block node chart. |
+
+> **Deprecated:** The `--dev` flag has been renamed to `--debug`. `--dev` still
+> works as an alias but is deprecated and prints a warning. The `--dev` alias
+> will no longer be supported once Solo `0.82.0` reaches its end of support
+> date.
 
 ---
 

--- a/content/en/docs/advanced-solo-setup/one-shot-deploy-with-custom-versions.md
+++ b/content/en/docs/advanced-solo-setup/one-shot-deploy-with-custom-versions.md
@@ -92,23 +92,8 @@ What this does:
 - Mirror Node, Relay, Explorer, Block Node, and the Solo chart keep their
   compiled-in edge defaults because no `*_EDGE_VERSION` was set for them.
 
-> **Note:** If you already have a running `one-shot` deployment and want to
-> keep it, the command above fails with
-> *"A deployment named one-shot already exists"* because `one-shot` is the
-> default deployment name. Pass `--deployment <name> --namespace <name>` to
-> deploy the edge build alongside the existing one:
->
-> ```bash
-> CONSENSUS_NODE_EDGE_VERSION=v0.74.0-rc.1 \
-> solo one-shot single deploy --edge --dev \
->   --deployment one-shot-edge --namespace one-shot-edge
-> ```
->
-> Every `solo one-shot` deploy overwrites `~/.solo/cache/last-one-shot-deployment.txt`
-> with its own deployment name. After this command, the cache file points at
-> `one-shot-edge`, not the original `one-shot`. Pass `--deployment` explicitly
-> when running follow-up commands against a specific deployment.
-
+> **Note:** Every successive `solo one-shot single deploy` command will remove the
+> existing components and will create a new deployment.
 ---
 
 ## Where to Find Version Tags

--- a/content/en/docs/advanced-solo-setup/one-shot-deploy-with-custom-versions.md
+++ b/content/en/docs/advanced-solo-setup/one-shot-deploy-with-custom-versions.md
@@ -78,7 +78,7 @@ Deploy a single-node network with a custom Consensus Node release candidate:
 
 ```bash
 CONSENSUS_NODE_EDGE_VERSION=v0.74.0-rc.1 \
-solo one-shot single deploy --edge --dev
+solo one-shot single deploy --edge --debug
 ```
 
 What this does:
@@ -87,13 +87,18 @@ What this does:
   version for this command invocation.
 - `--edge` tells Solo to read `*_EDGE_VERSION` variables instead of stable
   defaults.
-- `--dev` enables Solo's developer mode — appropriate for local development,
+- `--debug` enables Solo's debug mode — appropriate for local development,
   not for production-shaped deployments.
 - Mirror Node, Relay, Explorer, Block Node, and the Solo chart keep their
   compiled-in edge defaults because no `*_EDGE_VERSION` was set for them.
 
 > **Note:** Every successive `solo one-shot single deploy` command will remove the
 > existing components and will create a new deployment.
+
+> **Deprecated:** The `--dev` flag has been renamed to `--debug`. `--dev` still
+> works as an alias but is deprecated and prints a warning; update your scripts
+> to use `--debug`. The `--dev` alias will no longer be supported once Solo
+> `0.82.0` reaches its end of support date.
 ---
 
 ## Where to Find Version Tags
@@ -131,7 +136,7 @@ versions.
 ```bash
 CONSENSUS_NODE_EDGE_VERSION=<version> \
 MIRROR_NODE_EDGE_VERSION=<version> \
-solo one-shot single deploy --edge [--dev] [other flags]
+solo one-shot single deploy --edge [--debug] [other flags]
 ```
 
 ### Multi-node deploy
@@ -139,7 +144,7 @@ solo one-shot single deploy --edge [--dev] [other flags]
 ```bash
 CONSENSUS_NODE_EDGE_VERSION=<version> \
 MIRROR_NODE_EDGE_VERSION=<version> \
-solo one-shot multi deploy --edge --num-consensus-nodes 3 [--dev] [other flags]
+solo one-shot multi deploy --edge --num-consensus-nodes 3 [--debug] [other flags]
 ```
 
 ---
@@ -151,7 +156,7 @@ solo one-shot multi deploy --edge --num-consensus-nodes 3 [--dev] [other flags]
 ```bash
 CONSENSUS_NODE_EDGE_VERSION=v0.73.0 \
 MIRROR_NODE_EDGE_VERSION=v0.153.1 \
-solo one-shot single deploy --edge --dev
+solo one-shot single deploy --edge --debug
 ```
 
 ### Override every component
@@ -163,7 +168,7 @@ RELAY_EDGE_VERSION=0.77.0 \
 EXPLORER_EDGE_VERSION=27.0.0 \
 BLOCK_NODE_EDGE_VERSION=v0.32.0 \
 SOLO_CHART_EDGE_VERSION=0.64.0 \
-solo one-shot single deploy --edge --dev
+solo one-shot single deploy --edge --debug
 ```
 
 ### Export once, reuse across a development session
@@ -175,11 +180,11 @@ variables so every `one-shot` command in the shell session picks them up:
 export CONSENSUS_NODE_EDGE_VERSION=v0.74.0-rc.1
 export MIRROR_NODE_EDGE_VERSION=v0.153.1
 
-solo one-shot single deploy --edge --dev
+solo one-shot single deploy --edge --debug
 
 # Destroy and redeploy without re-typing the variables
 solo one-shot single destroy
-solo one-shot single deploy --edge --dev
+solo one-shot single deploy --edge --debug
 ```
 
 ---
@@ -223,7 +228,7 @@ invocation.
 
 ```bash
 # Stable defaults — *_EDGE_VERSION variables are ignored.
-solo one-shot single deploy --dev
+solo one-shot single deploy --debug
 ```
 
 If you want to pin versions without using `--edge` (for example, to test a

--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -58,7 +58,7 @@ Add-Content $PROFILE '$env:CONSENSUS_NODE_VERSION = "v0.73.0"'
 | `SOLO_HOME` | Path to the Solo cache and log files | `~/.solo`
 | `SOLO_CACHE_DIR` | Path to the Solo cache directory | `~/.solo/cache`
 | `SOLO_LOG_LEVEL` | Logging level for Solo operations. Accepted values: `trace`, `debug`, `info`, `warn`, `error` | `info`
-| `SOLO_DEV_OUTPUT` | Treat all commands as if the `--dev` flag were specified | `false`
+| `SOLO_DEV_OUTPUT` | Treat all commands as if the `--debug` flag were specified (`--debug` was formerly `--dev`) | `false`
 | `SOLO_CHAIN_ID` | Chain ID of the Solo network | `298`
 | `FORCE_PODMAN` | Force the use of Podman as the container engine when creating a new local cluster. Accepted values: `true`, `false` | `false`
 

--- a/content/en/docs/simple-solo-setup/managing-your-network.md
+++ b/content/en/docs/simple-solo-setup/managing-your-network.md
@@ -26,23 +26,14 @@ Before proceeding, ensure you have completed the following:
 > **Note:** If you need to upgrade an existing Solo network, see
 > [Upgrade Your Network](/docs/simple-solo-setup/upgrade-your-network).
 
-{{< tabpane text=true >}}
-{{% tab header="Bash" lang="bash" %}}
 ```bash
-cat ~/.solo/cache/last-one-shot-deployment.txt
+solo one-shot show deployment
 ```
-{{% /tab %}}
-{{% tab header="PowerShell" lang="powershell" %}}
-```powershell
-Get-Content $env:USERPROFILE\.solo\cache\last-one-shot-deployment.txt
-```
-{{% /tab %}}
-{{< /tabpane >}}
 
 Expected output — the deployment name you passed to `solo one-shot single deploy`, or the default `one-shot` if you did not specify `--deployment`:
 
   ```bash
-  one-shot% 
+  Deployment Name: one-shot (default)
   ```
 
 Most management commands require your deployment name. Find it with `solo one-shot show deployment` — see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name). It defaults to `one-shot` unless you passed `--deployment`. Use it as `<deployment-name>` in all commands on this page.
@@ -217,6 +208,6 @@ To find your deployment namespace, use any of:
   kubectl get pods -A | grep -v kube-system
   ```
 
-For one-shot deployments the namespace matches the deployment name in `~/.solo/cache/last-one-shot-deployment.txt` (on native Windows, `$env:USERPROFILE\.solo\cache\last-one-shot-deployment.txt`; default: `one-shot`).
+For one-shot deployments the namespace matches the deployment name, which defaults to `one-shot` unless you passed `--deployment` (retrieve it with `solo one-shot show deployment`).
 
 Replace `<namespace>` and `<pod-name>` with the values from your deployment.

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -211,15 +211,17 @@ To view the active port assignments:
 solo deployment config ports --deployment <deployment-name>
 ```
 
+The output directory is `one-shot-<deployment-name>`, and the default deployment name is `one-shot`. So the default output directory is `~/.solo/one-shot-one-shot/`.
+
 {{< tabpane text=true >}}
 {{% tab header="Bash" lang="bash" %}}
 ```bash
-cat ~/.solo/one-shot-$(cat ~/.solo/cache/last-one-shot-deployment.txt)/forwards
+cat ~/.solo/one-shot-one-shot/forwards
 ```
 {{% /tab %}}
 {{% tab header="PowerShell" lang="powershell" %}}
 ```powershell
-Get-Content "$env:USERPROFILE\.solo\one-shot-$(Get-Content $env:USERPROFILE\.solo\cache\last-one-shot-deployment.txt)\forwards"
+Get-Content "$env:USERPROFILE\.solo\one-shot-one-shot\forwards"
 ```
 {{% /tab %}}
 {{< /tabpane >}}
@@ -228,33 +230,15 @@ Get-Content "$env:USERPROFILE\.solo\one-shot-$(Get-Content $env:USERPROFILE\.sol
 -------------------------------------------------------------------------------
  - component 1: localhost:35211 -> pod:50211
 
-{{< tabpane text=true >}}
-{{% tab header="Bash" lang="bash" %}}
 ```bash
-solo deployment config info --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
+solo deployment config info --deployment one-shot
 ```
-{{% /tab %}}
-{{% tab header="PowerShell" lang="powershell" %}}
-```powershell
-solo deployment config info --deployment (Get-Content $env:USERPROFILE\.solo\cache\last-one-shot-deployment.txt)
-```
-{{% /tab %}}
-{{< /tabpane >}}
 
 To restore port-forwards after a system restart without redeploying:
 
-{{< tabpane text=true >}}
-{{% tab header="Bash" lang="bash" %}}
 ```bash
-solo deployment refresh port-forwards --deployment $(cat ~/.solo/cache/last-one-shot-deployment.txt)
+solo deployment refresh port-forwards --deployment one-shot
 ```
-{{% /tab %}}
-{{% tab header="PowerShell" lang="powershell" %}}
-```powershell
-solo deployment refresh port-forwards --deployment (Get-Content $env:USERPROFILE\.solo\cache\last-one-shot-deployment.txt)
-```
-{{% /tab %}}
-{{< /tabpane >}}
 
 ### Endpoints for Solo 0.62 and earlier
 

--- a/content/en/docs/simple-solo-setup/upgrade-your-network.md
+++ b/content/en/docs/simple-solo-setup/upgrade-your-network.md
@@ -47,4 +47,4 @@ After upgrading, confirm the network is healthy by checking pod status:
 kubectl get pods -n <namespace>
 ```
 
-For one-shot deployments, the namespace typically matches the deployment name in `~/.solo/cache/last-one-shot-deployment.txt`.
+For one-shot deployments, the namespace matches the deployment name, which defaults to `one-shot` unless you passed `--deployment` (retrieve it with `solo one-shot show deployment`).

--- a/content/en/docs/troubleshooting/_index.md
+++ b/content/en/docs/troubleshooting/_index.md
@@ -69,8 +69,11 @@ In the terminal, this appears inside a bordered `ERROR` box, followed by a tip
 suggesting `solo deployment diagnostics logs` or
 `solo deployment diagnostics report` to gather more detail.
 
-> **Note:** Add `--dev` to a command to see the full error cause chain and stack
-> traces instead of the summarized form — useful when filing a bug report.
+> **Note:** Add `--debug` to a command to see the full error cause chain and stack
+> traces instead of the summarized form — useful when filing a bug report. (This
+> flag was previously named `--dev`. The `--dev` alias still works but is
+> deprecated and will no longer be supported once Solo `0.82.0` reaches its end
+> of support date.)
 
 ## Common Issues and Solutions
 

--- a/content/en/docs/using-solo/local-builds.md
+++ b/content/en/docs/using-solo/local-builds.md
@@ -124,10 +124,11 @@ solo consensus node setup \
   --local-build-path /absolute/path/to/hiero-consensus-node/hedera-node/data
 ```
 
-Replace `<deployment-name>` with your deployment name — retrieve it with:
+Replace `<deployment-name>` with your deployment name. One-shot deployments use
+`one-shot` by default; You can see it with:
 
 ```bash
-cat ~/.solo/cache/last-one-shot-deployment.txt
+solo one-shot show deployment
 ```
 
 ---


### PR DESCRIPTION
**Description**:

This PR replaces all references to `--dev` with `--debug` and adds notes explaining the deprecation of `--dev`.
The change was introduced with this [PR in solo](https://github.com/hiero-ledger/solo/pull/4928)


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
