### PR TITLE
docs(using-environment-variables): add mirror node schema wait variables

### DIFF
--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -154,6 +154,10 @@ Add-Content $PROFILE '$env:CONSENSUS_NODE_VERSION = "v0.73.0"'
 | --- | --- | ---
 | `DISABLE_IMPORTER_SPRING_PROFILES` | Disable automatic configuration of Mirror Node importer Spring profiles for block-node integration. | `false`                                                                                            |
 | `SPRING_PROFILES_ACTIVE` | Spring profiles to use for the Mirror Node importer when automatic importer profile configuration is enabled. | `blocknode`                                                                                        |
+| `MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS` | Maximum number of attempts to check if the Mirror Node database schema has been built (signalled by importer pod readiness) | `900`
+| `MIRROR_NODE_SCHEMA_READY_DELAY` | Interval between Mirror Node database schema checks, in milliseconds | `2000`
+| `MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS` | Maximum number of attempts to detect a running Mirror Node importer pod. If no importer pod is found, the database schema wait is skipped | `15`
+| `MIRROR_NODE_IMPORTER_DETECT_DELAY` | Interval between Mirror Node importer pod detection attempts, in milliseconds | `2000`
 
 ---
 


### PR DESCRIPTION
## Description

Documents the four environment variables introduced by hiero-ledger/solo#5049 (`fix: wait for mirror node database schema before dependent readiness checks`) in the **Mirror Node** section of the [Using Environment Variables](https://solo.hiero.org/docs/advanced-solo-setup/using-environment-variables/) page:

| Variable | Default |
| --- | --- |
| `MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS` | `900` |
| `MIRROR_NODE_SCHEMA_READY_DELAY` | `2000` |
| `MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS` | `15` |
| `MIRROR_NODE_IMPORTER_DETECT_DELAY` | `2000` |

Descriptions and default values match `src/core/constants.ts` on the solo PR branch.

### Related Issues

* hiero-ledger/solo#5049
* hiero-ledger/solo#4967
