### PR TITLE
docs: deprecate Homebrew install, promote npm as primary method (#282)

### DIFF
--- a/content/en/docs/advanced-solo-setup/Deploy-Solo-on-a-GitHub-hosted-runner.md
+++ b/content/en/docs/advanced-solo-setup/Deploy-Solo-on-a-GitHub-hosted-runner.md
@@ -10,7 +10,7 @@ type: docs
 
 This guide is for developers who want to deploy a Solo network in CI to run integration
 tests against a live Hedera network from their own project. It uses the standard `ubuntu-latest`
-GitHub-hosted runner and the Solo CLI installed via Homebrew.
+GitHub-hosted runner and the Solo CLI installed via npm.
 
 For the hardware specs that runner provides, see
 [GitHub's documentation on standard hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
@@ -65,9 +65,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install Solo CLI
         run: |
-          brew install hiero-ledger/tools/solo
+          npm install -g @hiero-ledger/solo@latest
           solo --version
 
       - name: One-Shot Single Deploy

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -22,7 +22,7 @@ You can run one of the following commands depending on your needs:
     solo one-shot single deploy
     ```
 
-    > **Prerequisite:** Install Solo first with `brew install hiero-ledger/tools/solo`.
+    > **Prerequisite:** Install Solo first with `npm install -g @hiero-ledger/solo@latest`. See [System Readiness](/docs/simple-solo-setup/system-readiness) for full install instructions. Homebrew (`brew install hiero-ledger/tools/solo`) is deprecated and will stop receiving updates after August 31, 2026.
 
     For more information on Single Node Deployment, see [Quickstart](/docs/simple-solo-setup/quickstart#deploy-a-local-network-one-shot)
 

--- a/content/en/docs/simple-solo-setup/cleanup.md
+++ b/content/en/docs/simple-solo-setup/cleanup.md
@@ -121,10 +121,9 @@ docker volume prune
 ## Clean up legacy npm installations
 
 If you previously installed Solo via npm (for example, from older workshops or
-documentation), remove the global package to avoid conflicts with a newer
-Homebrew or npm install. Solo has been published under two npm names -
-`@hiero-ledger/solo` and `@hashgraph/solo` - so remove both to be sure no copy
-is left behind:
+documentation), remove the global package to avoid conflicts with a newer npm
+install. Solo has been published under two npm names — `@hiero-ledger/solo` and
+`@hashgraph/solo` — so remove both to be sure no copy is left behind:
 
 ```bash
 # Remove any npm-based Solo install (safe to run even if not present)

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -37,19 +37,21 @@ Before you begin, ensure you have completed the following:
 
 Install the latest Solo CLI globally using one of the following methods:
 
-- **Homebrew** (**recommended** for macOS/Linux/WSL2):
-
-  ```bash
-  brew install hiero-ledger/tools/solo
-  ```
-
-- **npm** (required for native Windows PowerShell; alternative on macOS/Linux/WSL2):
+- **npm** (**recommended** for all platforms):
 
   ```bash
   npm install -g @hiero-ledger/solo@latest
   ```
 
-  > **Note:** On macOS, Linux, and WSL2, Homebrew is recommended — it installs Node.js for you, whereas npm requires Node.js >= 22.0.0 to already be present (check with `node --version`; upgrade via [nvm](https://github.com/nvm-sh/nvm) or [nodejs.org](https://nodejs.org/en/download) if needed — Solo will fail with an `EBADENGINE` warning on Node.js 20.x or earlier). On native Windows (PowerShell), npm is the only available option. Regardless of installation method, Solo provisions kubectl, Helm, and Kind automatically at deploy time.
+  > **Note:** npm requires Node.js >= 22.0.0 to already be present (check with `node --version`; upgrade via [nvm](https://github.com/nvm-sh/nvm) or [nodejs.org](https://nodejs.org/en/download) if needed — Solo will fail with an `EBADENGINE` warning on Node.js 20.x or earlier). Solo provisions kubectl, Helm, and Kind automatically at deploy time.
+
+- **Homebrew** (deprecated — macOS/Linux/WSL2 only):
+
+  ```bash
+  brew install hiero-ledger/tools/solo
+  ```
+
+  > ⚠️ **Homebrew support is being deprecated.** Solo will stop publishing updates to Homebrew after August 31, 2026. New users should install via npm. Existing Homebrew users should migrate before August 31.
 
 ### Verify the installation
 
@@ -62,12 +64,12 @@ solo --version
 Expected output (version may be different):
 
 ```text
-** Solo **
-Version : 0.77.0
-**
+******************************* Solo *********************************************
+Version			: 0.84.0
+**********************************************************************************
 ```
 
-If you see a similar banner with a valid Solo version (for example, 0.59.1), your installation is successful.
+If you see a similar banner with a valid Solo version, your installation is successful.
 
 ## Deploy a local network (one-shot)
 

--- a/content/en/docs/simple-solo-setup/system-readiness.md
+++ b/content/en/docs/simple-solo-setup/system-readiness.md
@@ -34,8 +34,8 @@ install yourself.
 
 | Tool | Required version | How it is installed |
 | --- | --- | --- |
-| [Solo](https://github.com/hiero-ledger/solo) | latest | `brew install hiero-ledger/tools/solo`, or `npm install -g @hiero-ledger/solo` |
-| [Node.js](https://nodejs.org/en/download) | >= 22.0.0 (lts/jod) | **Homebrew installs it for you**; with **npm you install it yourself** |
+| [Solo](https://github.com/hiero-ledger/solo) | latest | `npm install -g @hiero-ledger/solo@latest` (recommended); `brew install hiero-ledger/tools/solo` (deprecated - Homebrew support ends August 31, 2026) |
+| [Node.js](https://nodejs.org/en/download) | >= 22.0.0 (lts/jod) | **You install it** (required for npm); Homebrew installs it automatically (deprecated) |
 | Container runtime ([Docker](https://www.docker.com/products/docker-desktop) / [Podman](https://podman.io)) | See [Docker](#docker) below | **You install it** — Docker Desktop (macOS/Windows) or Docker Engine (Linux). Solo auto-installs Podman on Linux/macOS/WSL2 if Docker Engine is not found. Not supported on native Windows. |
 | [kubectl](https://kubernetes.io/docs/reference/kubectl/) | >= v1.32.2 | **Solo provisions it** at deploy time - reuses a compatible copy already on your system, or downloads one into `~/.solo/bin` |
 | [Helm](https://helm.sh) | v3.14.2 | **Solo provisions it** at deploy time |
@@ -102,14 +102,20 @@ If using Podman instead of Docker Engine, ensure your system has at least 12 GB 
 
 Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, or via WSL2). Select your platform below to install the required container runtime and configure your environment, before proceeding to Quickstart:
 
+> ⚠️ **Homebrew support is being deprecated.** Solo will stop publishing updates to Homebrew after August 31, 2026. New users should install via npm. Existing Homebrew users should migrate before August 31.
+
 {{< tabpane text=true >}}
 
 {{% tab header="macOS" lang="macos" %}}
 
-1. Install Homebrew (if not already installed):
+1. Install Node.js (>= 22.0.0):
+
+    Download from [nodejs.org](https://nodejs.org/en/download), or install via [nvm](https://github.com/nvm-sh/nvm#installing-and-updating):
 
     ```sh
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    source ~/.nvm/nvm.sh
+    nvm install --lts
     ```
 
 2. Install Docker Desktop:
@@ -122,7 +128,7 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 3. Install Solo:
 
     ```sh
-    brew install hiero-ledger/tools/solo
+    npm install -g @hiero-ledger/solo@latest
     ```
 
 4. Verify the installation:
@@ -135,18 +141,17 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 
 {{% tab header="Linux" lang="linux" %}}
 
-1. Install Homebrew for Linux:
+1. Install Node.js (>= 22.0.0):
+
+    Using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating) (recommended):
 
     ```sh
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    source ~/.nvm/nvm.sh
+    nvm install --lts
     ```
 
-    Add Homebrew to your PATH:
-
-    ```sh
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
-    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-    ```
+    Or download from [nodejs.org](https://nodejs.org/en/download).
 
 2. Install Docker Engine (for Ubuntu/Debian):
 
@@ -163,7 +168,7 @@ Solo supports **macOS**, **Linux**, and **Windows** (natively with PowerShell, o
 3. Install Solo:
 
     ```sh
-    brew install hiero-ledger/tools/solo
+    npm install -g @hiero-ledger/solo@latest
     ```
 
 4. Verify the installation:
@@ -223,39 +228,28 @@ Run Solo natively from **Windows PowerShell**. Run every command below in a Powe
    wsl --install Ubuntu
    ```
 
-2. Install build tools required by Homebrew:
+2. Install Node.js (>= 22.0.0) inside the Ubuntu terminal:
+
+    Using [nvm](https://github.com/nvm-sh/nvm#installing-and-updating):
 
     ```sh
-    sudo apt-get install build-essential procps curl file git
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    source ~/.nvm/nvm.sh
+    nvm install --lts
     ```
 
-    > **Note:** These are the [Linux prerequisites for Homebrew](https://docs.brew.sh/Homebrew-on-Linux). Without `build-essential`, `brew install hiero-ledger/tools/solo` fails with `Error: ... must be built from source. Install Clang or run brew install gcc`. Only run this command on a trusted system.
-
-3. Install Homebrew for Linux:
-
-    ```sh
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    ```
-
-    Add Homebrew to your PATH:
-
-    ```sh
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
-    eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-    ```
-
-4. Install Docker Desktop for Windows:
+3. Install Docker Desktop for Windows:
     - Download from: [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop)
     - Enable WSL2 integration: Docker Desktop > Settings > Resources > WSL Integration.
     - Allocate at least 12 GB of memory: Docker Desktop > Settings > Resources > Memory.
 
-5. Install Solo:
+4. Install Solo:
 
     ```sh
-    brew install hiero-ledger/tools/solo
+    npm install -g @hiero-ledger/solo@latest
     ```
 
-6. Verify the installation:
+5. Verify the installation:
 
     ```sh
     solo --version
@@ -264,16 +258,6 @@ Run Solo natively from **Windows PowerShell**. Run every command below in a Powe
 {{% /tab %}}
 
 {{< /tabpane >}}
-
-## Alternative Installation: npm (for contributors and advanced users)
-
-If you need more control over dependencies or are contributing to Solo development, you can install Solo via npm instead of Homebrew.
-
-> **Note:** Node.js >= 22.0.0 and Kind must be installed separately before using this method.
-
-```bash
-npm install -g @hiero-ledger/solo
-```
 
 ## Optional Tools
 

--- a/content/en/docs/simple-solo-setup/upgrading-solo.md
+++ b/content/en/docs/simple-solo-setup/upgrading-solo.md
@@ -17,6 +17,8 @@ package manager you originally installed with. This page covers the Homebrew and
 npm upgrade paths, switching between them, and a clean-reinstall recipe for when
 an upgrade leaves Solo in a broken state.
 
+> ⚠️ **Homebrew support is being deprecated.** Solo will stop publishing updates to Homebrew after August 31, 2026. Existing Homebrew users should migrate to npm before August 31. See [Switching between Homebrew and npm](#switching-between-homebrew-and-npm).
+
 > **Tip:** Check your current version first with `solo --version`, and compare
 > it against the latest release on the
 > [Solo releases page](https://github.com/hiero-ledger/solo/releases).
@@ -113,7 +115,7 @@ Homebrew formula or npm tag instead of `latest`.
 > [Switching between Homebrew and npm](#switching-between-homebrew-and-npm).
 
 {{< tabpane text=true >}}
-{{% tab header="Homebrew" lang="homebrew" %}}
+{{% tab header="Homebrew (deprecated)" lang="homebrew" %}}
 ```bash
 brew install hiero-ledger/tools/solo@0.76.0
 ```
@@ -151,16 +153,15 @@ solo --version
 
 ## Switching between Homebrew and npm
 
-If you want to switch package managers (for example, from an older npm install
-to Homebrew), remove the existing copy first so you do not end up with two
-`solo` binaries on your `PATH`:
+To migrate from Homebrew to npm, remove the Homebrew copy first so you do not
+end up with two `solo` binaries on your `PATH`:
 
 ```bash
-# Remove the npm copy before installing via Homebrew (or vice versa)
-npm uninstall -g @hiero-ledger/solo
+# Remove the Homebrew copy before installing via npm
+brew uninstall hiero-ledger/tools/solo
 ```
 
-Then follow the install steps in
+Then install via npm following the steps in
 [System Readiness](/docs/simple-solo-setup/system-readiness#platform-setup).
 
 ## Clean reinstall
@@ -176,7 +177,7 @@ configuration, then reinstall.
 > with `solo one-shot single destroy` - see the
 > [Cleanup guide](/docs/simple-solo-setup/cleanup).
 
-{{< tabpane text=true >}} {{% tab header="Homebrew" lang="homebrew" %}}
+{{< tabpane text=true >}} {{% tab header="Homebrew (deprecated)" lang="homebrew" %}}
 
 ```bash
 brew uninstall hiero-ledger/tools/solo

--- a/content/en/docs/troubleshooting/_index.md
+++ b/content/en/docs/troubleshooting/_index.md
@@ -101,21 +101,29 @@ You are likely hitting an installation or upgrade problem if:
 
 1. **Confirm installation method**
 
-   If you previously installed Solo via npm and are now using Homebrew, remove
-   the npm install to avoid conflicts. Solo is published under two npm names
-   (`@hiero-ledger/solo` and `@hashgraph/solo`), so remove both:
+   If you previously installed Solo via Homebrew and are now migrating to npm,
+   remove the Homebrew install to avoid conflicts:
 
    ```bash
-   # Remove any npm-based Solo (if present)
-   if command -v npm >/dev/null 2>&1; then
-     npm uninstall -g @hiero-ledger/solo || true
-     npm uninstall -g @hashgraph/solo || true
-   fi
+   brew uninstall hiero-ledger/tools/solo
    ```
 
-   Then reinstall Solo using the steps in the
-   [Quickstart](/docs/simple-solo-setup/quickstart). If a global npm install
-   fails with `EEXIST` because both package names are present, see
+   Then install via npm:
+
+   ```bash
+   npm install -g @hiero-ledger/solo@latest
+   ```
+
+   If you have Solo installed under both npm package names (`@hiero-ledger/solo`
+   and `@hashgraph/solo`), remove both before reinstalling:
+
+   ```bash
+   npm uninstall -g @hiero-ledger/solo || true
+   npm uninstall -g @hashgraph/solo || true
+   ```
+
+   If a global npm install fails with `EEXIST` because both package names are
+   present, see
    [Resolving an `EEXIST` package-name conflict](/docs/simple-solo-setup/upgrading-solo#resolving-an-eexist-package-name-conflict).
 
 2. **Verify system resources**

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,23 @@
+{{/* Homebrew deprecation notice — remove after August 31, 2026 */}}
+<div class="pageinfo pageinfo-warning">
+  ⚠️ <strong>Homebrew support is being deprecated.</strong>
+  Solo will stop publishing updates to Homebrew after August 31, 2026.
+  Install via <code>npm install -g @hiero-ledger/solo@latest</code> instead.
+  See <a href="/docs/simple-solo-setup/system-readiness/#platform-setup">System Readiness</a> for full install instructions.
+</div>
+
+{{/* Archived version notice (keep for future use) */}}
+{{ if .Site.Params.archived_version }}
+{{ $color := "primary" }}
+{{ $latest_version := .Site.Params.url_latest_version }}
+{{ $current_version := .Site.Params.version }}
+<div class="pageinfo pageinfo-{{ $color }}">
+  {{ with $current_version }}<p>Version {{ . | markdownify }} of the
+    documentation is no longer actively maintained. The site that you are
+    currently viewing is an archived snapshot.
+    {{ with $latest_version }}For up-to-date documentation, see the
+      <a href="{{ $latest_version | safeURL }}" target="_blank">latest version</a>.</p>
+    {{ end }}
+  {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
**Description**:
- Add site-wide deprecation banner via layouts/partials/version-banner.html (remove after August 31, 2026).
- Make npm the recommended install method across all platform tabs (macOS, Linux, WSL2, Windows) in system-readiness and quickstart.
- Add Homebrew deprecation notices (sunset: August 31, 2026) to system-readiness, quickstart, upgrading-solo, faqs, troubleshooting, cleanup, and GitHub-hosted runner guide.
- Add Node.js install steps (nvm + source) to macOS, Linux, WSL2 tabs to cover the prerequisite Homebrew previously handled automatically.
- Add actions/setup-node@v4 (node-version: 22) to the GitHub runner workflow to satisfy Solo's >=22.0.0 engine requirement.
- Flip migration direction in troubleshooting from npm→Homebrew to Homebrew→npm.
- Update solo --version expected output to v0.84.0 banner format.

**Related issue(s)**:

Fixes #282 

**Notes for reviewer**:
To verify the docs, uninstalled Homebrew installed Solo on my local system and reinstalled Solo v0.84.0 using npm.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
