### PR TITLE
docs: add Step N labels to sequential H2 headings in setup guides (#264)

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -33,7 +33,7 @@ Before you begin, ensure you have completed the following:
 > **Note:** Quickstart only covers what you need to run `solo one-shot single deploy` and verify that the network is working.
 > Detailed version requirements, OS-specific notes, and optional tools are documented in the [System Readiness](/docs/simple-solo-setup/system-readiness).
 
-## Install Solo CLI
+## Step 1: Install Solo CLI
 
 Install the latest Solo CLI globally using one of the following methods:
 
@@ -71,7 +71,7 @@ Version			: 0.84.0
 
 If you see a similar banner with a valid Solo version, your installation is successful.
 
-## Deploy a local network (one-shot)
+## Step 2: Deploy a local network (one-shot)
 
 Use the one-shot command to create and configure a fully functional local Hiero network:
 
@@ -162,7 +162,7 @@ Confirm that all Solo-related pods are in a `Running` or `Completed` state.
 
 > **Tip:** The Solo testing team recommends [k9s](https://k9scli.io/) for managing Kubernetes clusters. It provides a terminal-based UI that makes it easy to view pods, logs, and cluster status. Install it with `brew install k9s` and run `k9s` to launch.
 
-## Access your local network
+## Step 3: Access your local network
 
 After the one-shot deployment completes and all pods are running, Solo sets up port-forwards so you can reach your local services. The endpoints below are the **default** ports for Solo 0.63 and later:
 
@@ -257,7 +257,7 @@ Open `http://localhost:8080` in your browser to explore your network.
 
 > **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible only via manual `kubectl port-forward`, and is being phased out. Always use the ingress-based port (`8081` for Solo 0.62 and earlier, `38081` for Solo 0.63+).
 
-## Tear down your network
+## Step 4: Tear down your network
 
 When you are finished, destroy the network to free up resources:
 

--- a/content/en/docs/simple-solo-setup/upgrade-your-network.md
+++ b/content/en/docs/simple-solo-setup/upgrade-your-network.md
@@ -23,11 +23,11 @@ Before upgrading, ensure you have completed the following:
 - **[System Readiness](/docs/simple-solo-setup/system-readiness)** - your local environment meets Solo requirements.
 - A currently running Solo deployment to upgrade.
 
-## Find your deployment name
+## Step 1: Find your deployment name
 
 The default for one-shot deployments is `one-shot`. If you used a different name, find it with `solo one-shot show deployment` (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)). Use that value as `<deployment-name>` in the upgrade command.
 
-## Upgrade the network
+## Step 2: Upgrade the network
 
 Run the following command to upgrade an existing Solo network deployment to a newer Hiero version:
 
@@ -39,7 +39,7 @@ Replace `<version>` with the target Hiero version, for example `v0.59.0`.
 
 > **Important:** This command is only for networks already deployed with Solo. Do not run it immediately after Quickstart unless you are moving an older deployment to a newer version.
 
-## Verify the upgrade
+## Step 3: Verify the upgrade
 
 After upgrading, confirm the network is healthy by checking pod status:
 


### PR DESCRIPTION
**Description**:
Add explicit "Step 1:", "Step 2:", … prefixes to the H2 headings in quickstart.md (4 steps) and upgrade-your-network.md (3 steps) so users can orient themselves in the procedure at a glance.

**Related issue(s)**:

Fixes #264 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
