### PR TITLE
docs: add canonical service endpoints reference page (#252)

### DIFF
--- a/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
+++ b/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
@@ -130,7 +130,7 @@ This configuration includes:
 | **Mirror Node**    | Stores and serves historical transaction data |
 | **Explorer UI**    | Web interface for viewing accounts            |
 
-Access the Explorer at: `http://localhost:38080/localnet/dashboard` (Solo 0.63+) or `http://localhost:8080/localnet/dashboard` (Solo 0.62 and earlier). See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) if the port is in use.
+Access the Explorer at: `http://localhost:38080/localnet/dashboard` (Solo 0.63+) or `http://localhost:8080/localnet/dashboard` (Solo 0.62 and earlier). See [Port availability](/docs/using-solo/endpoints#port-availability) if the port is in use.
 
 ### Deploy Network with Relay and Explorer
 
@@ -156,7 +156,7 @@ Access the services at (Solo 0.63+ defaults; for Solo 0.62 and earlier use the l
 - Explorer: `http://localhost:38080/localnet/dashboard` (legacy: `http://localhost:8080/localnet/dashboard`)
 - JSON-RPC Relay: `http://localhost:37546` (legacy: `http://localhost:7546`)
 
-> See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) if a port is already in use on your machine.
+> See [Port availability](/docs/using-solo/endpoints#port-availability) if a port is already in use on your machine.
 
 ## Available Taskfile Targets
 

--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -72,7 +72,7 @@ Add-Content $PROFILE '$env:CONSENSUS_NODE_VERSION = "v0.73.0"'
 | `SOLO_NODE_INTERNAL_GOSSIP_PORT` | Internal gossip port used by the Hiero network | `50111`
 | `SOLO_NODE_EXTERNAL_GOSSIP_PORT` | External gossip port used by the Hiero network | `50111`
 | `SOLO_NODE_DEFAULT_STAKE_AMOUNT` | Default stake amount for a node | `500`
-| `GRPC_PORT` | Local port-forward for consensus node gRPC. Default is `35211` for Solo 0.63+ (changed from `50211` to avoid Windows ephemeral-port conflicts). See [Port availability](/docs/simple-solo-setup/quickstart#port-availability). | `35211`
+| `GRPC_PORT` | Local port-forward for consensus node gRPC. Default is `35211` for Solo 0.63+ (changed from `50211` to avoid Windows ephemeral-port conflicts). See [Port availability](/docs/using-solo/endpoints#port-availability). | `35211`
 | `LOCAL_NODE_START_PORT` | Local node start port for the Solo network | `30212`
 
 ---

--- a/content/en/docs/faqs.md
+++ b/content/en/docs/faqs.md
@@ -93,28 +93,10 @@ solo one-shot single deploy
 
 ### How do I access services after deployment?
 
-After running `solo one-shot single deploy`, the following services are available on localhost. The ports below are the **defaults for Solo 0.63 and later**:
-
-| Service               | Endpoint                 | Description                                      |
-| --------------------- | ------------------------ | ------------------------------------------------ |
-| Explorer UI           | `http://localhost:38080` | Web UI for inspecting accounts and transactions. |
-| Consensus node (gRPC) | `localhost:35211`        | gRPC endpoint for submitting transactions.       |
-| Mirror node REST API  | `http://localhost:38081` | REST API for querying historical data.           |
-| JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint.           |
-
-- Open `http://localhost:38080` in your browser to start exploring your local network.
-
-- To verify these services are reachable, you can run a quick health check:
-
-    ```bash
-    # Mirror node REST API
-    curl -s "http://localhost:38081/api/v1/transactions?limit=1"
-    
-    # JSON RPC relay
-    curl -s -X POST http://localhost:37546 \
-      -H "Content-Type: application/json" \
-      --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-    ```
+After running `solo one-shot single deploy`, your local services are available on
+localhost. For the complete endpoint reference — default ports for Solo 0.63+
+and Solo 0.62 and earlier, verification commands, and port lookup — see
+[**Service Endpoints**](/docs/using-solo/endpoints).
 
 - If any service is unreachable, confirm that all pods are healthy first:
 
@@ -124,26 +106,15 @@ After running `solo one-shot single deploy`, the following services are availabl
 
     All Solo-related pods should be in a `Running` or `Completed` state before the endpoints become available.
 
-> **Note:** These are Solo's default port targets. If a port is already in use on your machine, Solo automatically selects the next available port. The actual ports used are printed at the end of deployment and saved to `~/.solo/<deployment-name>/forwards`. See [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for details.
-
-**Solo 0.62 and earlier** used different default ports:
-
-| Service               | Endpoint                | Description                                      |
-| --------------------- | ----------------------- | ------------------------------------------------ |
-| Explorer UI           | `http://localhost:8080` | Web UI for inspecting accounts and transactions. |
-| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for submitting transactions.       |
-| Mirror node REST API  | `http://localhost:8081` | REST API for querying historical data (via mirror-ingress). |
-| JSON RPC relay        | `http://localhost:7546` | Ethereum-compatible JSON RPC endpoint.           |
-
-> **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible only via manual `kubectl port-forward`, and is being phased out. The ingress-based port (`8081` for older Solo, `38081` for Solo 0.63+) is the recommended entry point.
-
 ### How do I connect my application to the local network?
 
-Use these endpoints (Solo 0.63 and later):
+Use these endpoints with your SDK or tooling (Solo 0.63 and later):
 
-- **gRPC (Hedera SDK)**: `localhost:35211`, Node ID: `0.0.3`
-- **JSON RPC (Ethereum tools)**: `http://localhost:37546`
+- **Hiero SDK (gRPC)**: `localhost:35211`, node account ID `0.0.3`
+- **EVM tools (JSON-RPC)**: `http://localhost:37546`
 - **Mirror Node REST**: `http://localhost:38081/api/v1/`
+
+For verification commands, legacy ports, and port lookup, see [Service Endpoints](/docs/using-solo/endpoints).
 
 ### What should I do if `solo one-shot single destroy` fails or my Solo state is corrupted?
 

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -164,98 +164,12 @@ Confirm that all Solo-related pods are in a `Running` or `Completed` state.
 
 ## Access your local network
 
-After the one-shot deployment completes and all pods are running, Solo sets up port-forwards so you can reach your local services. The endpoints below are the **default** ports for Solo 0.63 and later:
-
-| Service               | Endpoint                 | Description                            | Verification |
-|-----------------------|--------------------------|----------------------------------------|--------------|
-| Explorer UI           | `http://localhost:38080` | Web UI for inspecting the network.     | Open URL in your browser |
-| Consensus node (gRPC) | `localhost:35211`        | gRPC endpoint for transactions.        | `nc -zv localhost 35211` |
-| Mirror node REST API  | `http://localhost:38081` | REST API for queries.                  | `curl http://localhost:38081/api/v1/transactions` |
-| JSON RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON RPC endpoint. | `curl -X POST http://localhost:37546 -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'` |
-
-> **macOS note:** Running `nc -zv localhost 35211` may print two lines:
-> ```text
-> nc: connectx to localhost port 35211 (tcp) failed: Connection refused
-> Connection to localhost port 35211 [tcp/*] succeeded!
-> ```
-> The first line is a failed IPv6 attempt - this is expected on macOS.
-> The second line confirms the IPv4 connection succeeded. The port is reachable.
+After the one-shot deployment completes and all pods are running, Solo sets up
+port-forwards so you can reach your local services. For the full endpoint
+reference — default ports for Solo 0.63+ and Solo 0.62 and earlier, verification
+commands, and port lookup — see [**Service Endpoints**](/docs/using-solo/endpoints).
 
 Open `http://localhost:38080` in your browser to explore your network.
-
-The `Verification` commands above use bash tools (`nc`, `curl`). On native Windows, run the PowerShell equivalents instead:
-
-```powershell
-# Consensus node (gRPC)
-Test-NetConnection localhost -Port 35211
-
-# Mirror node REST API
-Invoke-RestMethod http://localhost:38081/api/v1/transactions
-
-# JSON RPC relay
-Invoke-RestMethod -Method Post -Uri 'http://localhost:37546' -ContentType 'application/json' -Body '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
-```
-
-> **Note:** In PowerShell, `curl` is an alias for `Invoke-WebRequest`, so the bash `curl` flags above will not work. Use `curl.exe` explicitly if you prefer the bash-style syntax.
-
-### Port availability
-
-The ports above are Solo's defaults. Solo uses `kubectl port-forward` to tunnel traffic from your machine to services running inside Kubernetes. Before opening each tunnel, Solo tries the configured port:
-
-- If the port is free, Solo logs: `Using requested port <port>`.
-- If the port is already occupied (by another process, or by a previous Solo session that did not clean up its port-forwards), Solo finds the next available port and logs: `Using available port <port>`.
-
-The actual ports used are printed at the end of `solo one-shot single deploy`. You can also look them up at any time with the Solo CLI, using your deployment name (see [Capture your deployment name](#capture-your-deployment-name)).
-
-To view the active port assignments:
-
-```bash
-solo deployment config ports --deployment <deployment-name>
-```
-
-The output directory is `one-shot-<deployment-name>`, and the default deployment name is `one-shot`. So the default output directory is `~/.solo/one-shot-one-shot/`.
-
-{{< tabpane text=true >}}
-{{% tab header="Bash" lang="bash" %}}
-```bash
-cat ~/.solo/one-shot-one-shot/forwards
-```
-{{% /tab %}}
-{{% tab header="PowerShell" lang="powershell" %}}
-```powershell
-Get-Content "$env:USERPROFILE\.solo\one-shot-one-shot\forwards"
-```
-{{% /tab %}}
-{{< /tabpane >}}
-
- *** Consensus node gRPC ***
--------------------------------------------------------------------------------
- - component 1: localhost:35211 -> pod:50211
-
-```bash
-solo deployment config info --deployment one-shot
-```
-
-To restore port-forwards after a system restart without redeploying:
-
-```bash
-solo deployment refresh port-forwards --deployment one-shot
-```
-
-### Endpoints for Solo 0.62 and earlier
-
-If you are using Solo 0.62 or earlier, the default port-forward targets differ:
-
-| Service               | Endpoint                | Description                            |
-|-----------------------|-------------------------|----------------------------------------|
-| Explorer UI           | `http://localhost:8080` | Web UI for inspecting the network.     |
-| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for transactions.        |
-| Mirror node REST API  | `http://localhost:8081` | REST API for queries (via mirror-ingress). |
-| JSON RPC relay        | `http://localhost:7546` | Ethereum-compatible JSON RPC endpoint. |
-
-Open `http://localhost:8080` in your browser to explore your network.
-
-> **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible only via manual `kubectl port-forward`, and is being phased out. Always use the ingress-based port (`8081` for Solo 0.62 and earlier, `38081` for Solo 0.63+).
 
 ## Tear down your network
 

--- a/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
+++ b/content/en/docs/using-solo/accessing-solo-services/solo-with-mirror-node.md
@@ -209,7 +209,12 @@ In most cases you should use `localhost:38081` (Solo 0.63+) or `localhost:8081` 
 
 ## Port Reference
 
-The ports listed below are Solo's **default** targets. Solo checks each port before opening a tunnel - if the port is already in use, Solo picks the next available one and logs `Using available port <port>`. If an endpoint is not reachable, check the actual ports your deployment is using with `solo deployment config ports --deployment <deployment-name>` - see [Port availability](/docs/simple-solo-setup/quickstart#port-availability) for the full set of commands.
+> For the full network endpoint reference (consensus gRPC, Mirror Node REST,
+> JSON-RPC Relay, and Explorer), see [Service Endpoints](/docs/using-solo/endpoints).
+> The table below covers mirror-node-specific ports, including those accessible
+> only via manual `kubectl port-forward`.
+
+The ports listed below are Solo's **default** targets. Solo checks each port before opening a tunnel - if the port is already in use, Solo picks the next available one and logs `Using available port <port>`. If an endpoint is not reachable, check the actual ports your deployment is using with `solo deployment config ports --deployment <deployment-name>` - see [Port availability](/docs/using-solo/endpoints#port-availability) for the full set of commands.
 
 The default local ports depend on your Solo version:
 

--- a/content/en/docs/using-solo/endpoints.md
+++ b/content/en/docs/using-solo/endpoints.md
@@ -1,0 +1,159 @@
+---
+title: "Service Endpoints"
+weight: 1
+description: >
+  Default service endpoints for a Solo one-shot deployment. Quick reference
+  for the Hiero consensus gRPC address, Mirror Node REST URL, JSON-RPC Relay
+  port, and Explorer URL — for both Solo 0.63+ and Solo 0.62 and earlier.
+categories: ["Reference"]
+tags: ["endpoints", "ports", "gRPC", "mirror-node", "json-rpc", "explorer"]
+type: docs
+---
+
+## Overview
+
+After a successful `solo one-shot single deploy`, Solo sets up port-forwards to
+the following local services. Use these endpoints to connect your application,
+SDK, or tooling to the running network.
+
+> **Note:** The ports below are Solo's default targets. If a port is already in
+> use on your machine, Solo automatically selects the next available port and
+> logs `Using available port <port>`. See [Port availability](#port-availability)
+> for how to look up the ports your deployment is actually using.
+
+## Solo 0.63 and later (current defaults)
+
+| Service               | Endpoint                 | Description                                      |
+|-----------------------|--------------------------|--------------------------------------------------|
+| Explorer UI           | `http://localhost:38080` | Web UI for inspecting accounts and transactions. |
+| Consensus node (gRPC) | `localhost:35211`        | gRPC endpoint for submitting transactions.       |
+| Mirror node REST API  | `http://localhost:38081` | REST API for querying historical data.           |
+| JSON-RPC relay        | `http://localhost:37546` | Ethereum-compatible JSON-RPC endpoint.           |
+
+### Verify the endpoints
+
+{{< tabpane text=true >}}
+{{% tab header="Bash" lang="bash" %}}
+```bash
+# Consensus node (gRPC)
+nc -zv localhost 35211
+
+# Mirror node REST API
+curl http://localhost:38081/api/v1/transactions
+
+# JSON-RPC relay
+curl -X POST http://localhost:37546 \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+```
+{{% /tab %}}
+{{% tab header="PowerShell" lang="powershell" %}}
+```powershell
+# Consensus node (gRPC)
+Test-NetConnection localhost -Port 35211
+
+# Mirror node REST API
+Invoke-RestMethod http://localhost:38081/api/v1/transactions
+
+# JSON-RPC relay
+Invoke-RestMethod -Method Post -Uri 'http://localhost:37546' `
+  -ContentType 'application/json' `
+  -Body '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+> **macOS note:** Running `nc -zv localhost 35211` may print two lines:
+> ```text
+> nc: connectx to localhost port 35211 (tcp) failed: Connection refused
+> Connection to localhost port 35211 [tcp/*] succeeded!
+> ```
+> The first line is a failed IPv6 attempt — this is expected on macOS.
+> The second line confirms the IPv4 connection succeeded. The port is reachable.
+
+> **Note:** In PowerShell, `curl` is an alias for `Invoke-WebRequest`, so bash
+> `curl` flags will not work. Use `curl.exe` explicitly if you prefer the
+> bash-style syntax.
+
+## Solo 0.62 and earlier
+
+If you are using Solo 0.62 or earlier, the default port-forward targets differ:
+
+| Service               | Endpoint                | Description                                           |
+|-----------------------|-------------------------|-------------------------------------------------------|
+| Explorer UI           | `http://localhost:8080` | Web UI for inspecting accounts and transactions.      |
+| Consensus node (gRPC) | `localhost:50211`       | gRPC endpoint for submitting transactions.            |
+| Mirror node REST API  | `http://localhost:8081` | REST API for querying historical data (via mirror-ingress). |
+| JSON-RPC relay        | `http://localhost:7546` | Ethereum-compatible JSON-RPC endpoint.                |
+
+> **Note:** `localhost:5551` is the direct Mirror Node REST service, accessible
+> only via manual `kubectl port-forward`, and is being phased out. Always use
+> the ingress-based port (`8081` for Solo 0.62 and earlier, `38081` for
+> Solo 0.63+).
+
+## Connecting your application
+
+Quick reference for SDK and tooling configuration (Solo 0.63 and later):
+
+- **Hiero SDK (gRPC)**: `localhost:35211`, node account ID `0.0.3`
+- **EVM tools (JSON-RPC)**: `http://localhost:37546`
+- **Mirror Node REST**: `http://localhost:38081/api/v1/`
+
+For SDK-specific connection examples, see:
+
+- [Using Solo with Hiero SDKs](/docs/using-solo/using-solo-with-hiero-sdks)
+- [Using Solo with EVM Tools](/docs/using-solo/using-solo-with-evm-tools)
+- [Accessing Solo Services](/docs/using-solo/accessing-solo-services/)
+
+## Port availability
+
+Solo uses `kubectl port-forward` to tunnel traffic from your machine to services
+running inside Kubernetes. Before opening each tunnel, Solo tries the configured
+port:
+
+- If the port is free, Solo logs: `Using requested port <port>`.
+- If the port is already occupied (by another process, or by a previous Solo
+  session that did not clean up its port-forwards), Solo finds the next
+  available port and logs: `Using available port <port>`.
+
+The actual ports used are printed at the end of `solo one-shot single deploy`.
+You can also look them up at any time with the Solo CLI, using your deployment
+name (see [Capture your deployment name](/docs/simple-solo-setup/quickstart#capture-your-deployment-name)).
+
+To view the active port assignments:
+
+```bash
+solo deployment config ports --deployment <deployment-name>
+```
+
+The output directory is `one-shot-<deployment-name>`, and the default deployment
+name is `one-shot`. So the default output directory is `~/.solo/one-shot-one-shot/`.
+
+{{< tabpane text=true >}}
+{{% tab header="Bash" lang="bash" %}}
+```bash
+cat ~/.solo/one-shot-one-shot/forwards
+```
+{{% /tab %}}
+{{% tab header="PowerShell" lang="powershell" %}}
+```powershell
+Get-Content "$env:USERPROFILE\.solo\one-shot-one-shot\forwards"
+```
+{{% /tab %}}
+{{< /tabpane >}}
+
+```text
+ *** Consensus node gRPC ***
+-------------------------------------------------------------------------------
+ - component 1: localhost:35211 -> pod:50211
+```
+
+```bash
+solo deployment config info --deployment one-shot
+```
+
+To restore port-forwards after a system restart without redeploying:
+
+```bash
+solo deployment refresh port-forwards --deployment one-shot
+```


### PR DESCRIPTION
**Description**:
As per issue #252: A developer connecting an app to Solo must search across multiple pages to find the gRPC address, Mirror Node REST URL, JSON-RPC relay port, and Explorer URL. There is no single reference showing all endpoints in one place, so add `endpoints.md` as the single source of truth for Solo network service endpoints for both Solo 0.63+ and Solo 0.62 and earlier, and cross-reference it to other docs wherever required. 


**Related issue(s)**:

Fixes #252 

**Notes for reviewer**:
Tested against solo v0.84.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
