### PR TITLE
docs: add first-run time estimate to one-shot deploy in Quickstart (#265)

### DIFF
--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -87,10 +87,10 @@ This command performs the following actions:
 - Exposes gRPC and JSON-RPC endpoints for client access.
 
 > **⏱ First-run time:** `solo one-shot single deploy` typically takes
-> **10–20 minutes** on first run while Solo pulls the required container images.
-> Long pauses with no visible output change are normal — the deploy is still
-> running. Later deployments reuse the local image cache and complete faster.
-> See [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
+> **3–5 minutes**. Long pauses with no visible output change are normal — the
+> deploy is still running. The first run may take slightly longer if Solo needs
+> to pull container images. Later deployments reuse the local image cache and
+> complete faster. See [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
 
 > **Note:** During deployment you may see `Stopping port-forward for port [N]`
 > printed in yellow. This is expected - as it sets up the network, Solo stops

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -87,10 +87,12 @@ This command performs the following actions:
 - Exposes gRPC and JSON-RPC endpoints for client access.
 
 > **⏱ First-run time:** `solo one-shot single deploy` typically takes
-> **3–5 minutes**. Long pauses with no visible output change are normal — the
-> deploy is still running. The first run may take slightly longer if Solo needs
-> to pull container images. Later deployments reuse the local image cache and
-> complete faster. See [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
+> **3–5 minutes** when container images are already cached locally, or
+> **10–20 minutes** on the very first run while Solo pulls images over the
+> network (longer on slower connections). Long pauses with no visible output
+> change are normal — the deploy is still running. Later deployments reuse the
+> local image cache and complete faster. See
+> [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
 
 > **Note:** During deployment you may see `Stopping port-forward for port [N]`
 > printed in yellow. This is expected - as it sets up the network, Solo stops

--- a/content/en/docs/simple-solo-setup/quickstart.md
+++ b/content/en/docs/simple-solo-setup/quickstart.md
@@ -86,9 +86,11 @@ This command performs the following actions:
 - Sets up and funds default test accounts.
 - Exposes gRPC and JSON-RPC endpoints for client access.
 
-> **Tip:** Solo caches the container images it pulls, so your first deployment
-> may take longer while images download; later deployments reuse the local cache
-> and start faster. See [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
+> **⏱ First-run time:** `solo one-shot single deploy` typically takes
+> **10–20 minutes** on first run while Solo pulls the required container images.
+> Long pauses with no visible output change are normal — the deploy is still
+> running. Later deployments reuse the local image cache and complete faster.
+> See [Solo Image Cache](/docs/advanced-solo-setup/image-cache).
 
 > **Note:** During deployment you may see `Stopping port-forward for port [N]`
 > printed in yellow. This is expected - as it sets up the network, Solo stops


### PR DESCRIPTION
**Description**:
Replace the vague image-cache tip with a concrete time callout: 10–20 minutes on first run; long pauses are normal; later deploys are faster due to local image caching.

**Related issue(s)**:

Fixes #265 

**Notes for reviewer**:
Doc changes only

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
