### PR TITLE
docs(using-environment-variables): add mirror node chart upgrade retry variables

### DIFF
--- a/content/en/docs/advanced-solo-setup/using-environment-variables.md
+++ b/content/en/docs/advanced-solo-setup/using-environment-variables.md
@@ -158,6 +158,8 @@ Add-Content $PROFILE '$env:CONSENSUS_NODE_VERSION = "v0.73.0"'
 | `MIRROR_NODE_SCHEMA_READY_DELAY` | Interval between Mirror Node database schema checks, in milliseconds | `2000`
 | `MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS` | Maximum number of attempts to detect a running Mirror Node importer pod. If no importer pod is found, the database schema wait is skipped | `15`
 | `MIRROR_NODE_IMPORTER_DETECT_DELAY` | Interval between Mirror Node importer pod detection attempts, in milliseconds | `2000`
+| `MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS` | Maximum number of attempts to install or upgrade the Mirror Node Helm chart before failing. Retries ride out transient Kubernetes API server outages | `3`
+| `MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS` | Delay between Mirror Node Helm chart install/upgrade attempts, in seconds | `15`
 
 ---
 


### PR DESCRIPTION
## Description

Documents the two environment variables introduced by hiero-ledger/solo#5686 (`fix: retry mirror node chart upgrade to ride out transient API server outages`) in the **Mirror Node** section of the [Using Environment Variables](https://solo.hiero.org/docs/advanced-solo-setup/using-environment-variables/) page:

| Variable | Default |
| --- | --- |
| `MIRROR_NODE_CHART_UPGRADE_MAX_ATTEMPTS` | `3` |
| `MIRROR_NODE_CHART_UPGRADE_RETRY_DELAY_SECS` | `15` |

Descriptions and default values match `src/core/constants.ts` on the solo PR branch.

### Related Issues

* hiero-ledger/solo#5686
* hiero-ledger/solo#5607
