### PR TITLE
docs: expand performance-tests-local guide with verified test details

### DIFF
--- a/content/en/docs/advanced-solo-setup/performance-tests-local/_index.md
+++ b/content/en/docs/advanced-solo-setup/performance-tests-local/_index.md
@@ -33,6 +33,131 @@ task test-e2e-performance
 The test uses one-shot single deploy/destroy flow and then runs rapid-fire load
 tests.
 
+## What Gets Tested
+
+The test suite runs four sequential load tests using the Network Load Generator
+(NLG), each for 5 minutes by default (controlled by
+`ONE_SHOT_METRICS_TEST_DURATION_IN_MINUTES`):
+
+| Load Test              | What it submits                          |
+|------------------------|------------------------------------------|
+| `TokenTransferLoadTest`  | Fungible token transfers                 |
+| `NftTransferLoadTest`    | NFT transfers                            |
+| `CryptoTransferLoadTest` | HBAR crypto transfers                    |
+| `HCSLoadTest`            | Hedera Consensus Service (HCS) messages  |
+
+All four tests target a max of **100 TPS** with 5 concurrent threads and 1,000
+accounts. After all load tests complete, the suite sleeps for one additional
+metrics-collection window to capture steady-state resource usage.
+
+## Metrics Measured
+
+The test collects two categories of metrics:
+
+### Workload metrics (per load test)
+
+| Metric | Unit | Description |
+|---|---|---|
+| TPS | transactions/second | Throughput achieved by the NLG during the load window |
+| Transaction count | count | Total transactions submitted in the load window |
+| End-to-end mirror RTT | milliseconds | Time from transaction submission to visibility in the Mirror Node REST API |
+| RTT percentiles (p50, p95, max) | milliseconds | Distribution of 5 RTT probe samples taken concurrently during each load test |
+
+### Kubernetes resource metrics (polled every 5 seconds)
+
+| Metric | Unit | Description |
+|---|---|---|
+| CPU | millicores | Aggregate CPU across all pods in the test namespace |
+| Memory | MiB | Aggregate memory across all pods in the test namespace |
+| Peak CPU | millicores | Highest CPU snapshot recorded across the full test run |
+| Peak memory | MiB | Highest memory snapshot recorded across the full test run |
+
+Per-pod breakdowns are included in the JSON output for post-run analysis.
+
+## Expected Output
+
+### Console output (per load test)
+
+A healthy run prints a green result line after each load test:
+
+```text
+TokenTransferLoadTest: TPS 100 (30000 transactions in 300 sec), RTT 450 ms
+TokenTransferLoadTest: end-to-end mirror RTT max 499 ms (p50 320 ms, p95 480 ms, 5 samples)
+```
+
+During the post-test metrics collection window you will see:
+
+```text
+performance-tests: sleeping for metrics collection, 1 of 5 minutes
+performance-tests: sleeping for metrics collection, 2 of 5 minutes
+...
+performance-tests: sleeping for metrics collection, 5 of 5 minutes
+```
+
+### Summary JSON
+
+After the test completes, a summary is written to
+`~/.solo/logs/<namespace>.json`. The example below shows the structure and
+fields — actual values will differ based on your hardware and Solo version:
+
+```json
+{
+  "snapshotName": "performance-tests-3712495",
+  "date": "2026-07-28T10:15:42.123Z",
+  "gitHubSha": "",
+  "soloVersion": "0.85.0",
+  "soloChartVersion": "0.65.0",
+  "consensusNodeVersion": "v0.74.0",
+  "mirrorNodeVersion": "0.159.0",
+  "blockNodeVersion": "0.38.0",
+  "relayVersion": "0.77.0",
+  "explorerVersion": "26.1.0",
+  "cpuInMillicores": 1842,
+  "memoryInMebibytes": 2331,
+  "runtimeInMinutes": 62,
+  "transactionCount": 120000,
+  "events": [
+    "Starting TokenTransferLoadTest",
+    "Starting NftTransferLoadTest",
+    "Starting CryptoTransferLoadTest",
+    "Starting HCSLoadTest",
+    "Completed all performance tests"
+  ],
+  "peakCpuInMillicores": 2100,
+  "peakCpuSnapshot": "performance-tests-3712495",
+  "peakMemoryInMebibytes": 2331,
+  "peakMemorySnapshot": "performance-tests-3712495",
+  "clusterMetrics": ["..."]
+}
+```
+
+A full timeline of all 5-second snapshots is written to
+`~/.solo/logs/<namespace>/timeline-metrics.json` for trend analysis.
+
+## Interpreting Results
+
+### Healthy indicators
+
+| Signal | What to look for |
+|---|---|
+| All four load tests print a green result line | TPS reported as non-zero |
+| `events` array ends with `"Completed all performance tests"` | All tests ran to completion |
+| `memoryInMebibytes` under **3,000 MiB** | CI threshold — above this indicates a regression |
+| End-to-end mirror RTT under **600 ms** | RTT probe target; values near or above this indicate mirror node lag |
+
+### Problem indicators
+
+| Signal | Likely cause |
+|---|---|
+| A load test prints no result line or exits with `NO_RESULT` | NLG pod failed to start or crashed mid-run |
+| TPS is 0 with 0 transactions | Consensus node was unreachable or rejected all transactions |
+| `memoryInMebibytes` above 3,000 MiB | Memory regression — compare per-pod breakdown in `clusterMetrics` to identify the culprit |
+| RTT consistently above 600 ms | Mirror node importer lag; check importer pod logs |
+| `events` array is missing later entries | Test timed out or threw before completing all load tests |
+
+> **Note:** The `SmartContractLoadTest` is currently disabled (`it.skip`) pending
+> an upstream fix and will not appear in results.
+
 ## Optional: Use a Local Consensus Node Build
 
 If you already have a local consensus node build, set `SOLO_LOCAL_BUILD_PATH` so


### PR DESCRIPTION
**Description**:
Add four new sections verified against Solo v0.85.0 source:
- What Gets Tested: four NLG load tests, targets (100 TPS, 5 threads, 1000 accounts, 5 min default), post-test sleep window
- Metrics Measured: workload metrics (TPS, tx count, RTT + percentiles) and Kubernetes resource metrics (CPU/memory, peak values, per-pod data)
- Expected Output: console format from rapid-fire.ts, sleep messages from performance.test.ts, and annotated summary JSON from aggregated-metrics.ts
- Interpreting Results: healthy vs problem indicators with CI thresholds (3000 MiB memory, 600 ms RTT)

**Related issue(s)**:

Fixes #262 

**Notes for reviewer**:
Tested against Solo v0.85.0

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
