### PR TITLE
chore: remove solo init command references

### DIFF
--- a/content/en/docs/advanced-solo-setup/cli/cli-migrations.md
+++ b/content/en/docs/advanced-solo-setup/cli/cli-migrations.md
@@ -21,7 +21,6 @@ For full current syntax and flags, see [Solo CLI Reference](/docs/advanced-solo-
 
 | Legacy command | Current command |
 | --- | --- |
-| `init` | `init` |
 | `block node add` | `block node add` |
 | `block node destroy` | `block node destroy` |
 | `block node upgrade` | `block node upgrade` |

--- a/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
+++ b/content/en/docs/advanced-solo-setup/customizing-solo-with-tasks.md
@@ -295,7 +295,6 @@ Low-level tasks for managing clusters and network infrastructure:
 | `cluster:create`            | Create a Kind (Kubernetes in Docker) cluster               |
 | `cluster:destroy`           | Delete the Kind cluster                                    |
 | `solo:cluster:setup`        | Setup cluster infrastructure and prerequisites             |
-| `solo:init`                 | Initialize Solo (download tools and templates)             |
 | `solo:deployment:create`    | Create a new deployment configuration                      |
 | `solo:deployment:attach`    | Attach an existing cluster to a deployment                 |
 | `solo:network:deploy`       | Deploy the consensus network to the cluster                |


### PR DESCRIPTION
## Summary

`solo init` has been removed from the Solo CLI in hiero-ledger/solo#5835 (deprecated since v0.85.0). This removes two stale references from the docs:

- **`cli-migrations.md`**: Remove the `init → init` row from the legacy-to-current mapping table (the command no longer exists in any version).
- **`customizing-solo-with-tasks.md`**: Remove the `solo:init` row from the Taskfile task reference table.

The generated CLI reference (`solo-cli.md`) will automatically drop the `init` section when the next docs build regenerates it from the new Solo CLI help output.

## Test plan

- [ ] Verify no broken links or references to `solo init` remain in authored content

🤖 Generated with [Claude Code](https://claude.ai/claude-code)