### PR TITLE
docs: add documentation for port-forwards stop command

### DIFF
--- a/content/en/docs/using-solo/endpoints.md
+++ b/content/en/docs/using-solo/endpoints.md
@@ -155,5 +155,21 @@ solo deployment config info --deployment one-shot
 To restore port-forwards after a system restart without redeploying:
 
 ```bash
-solo deployment refresh port-forwards --deployment one-shot
+solo deployment port-forwards refresh --deployment one-shot
 ```
+
+> **Note:** `solo deployment refresh port-forwards` still works but is
+> deprecated in favor of `solo deployment port-forwards refresh` and will be
+> removed in a future release.
+
+To stop all port-forwards for a deployment (for example, before shutting down
+your machine):
+
+```bash
+solo deployment port-forwards stop --deployment one-shot
+```
+
+This closes the underlying `kubectl port-forward` processes and removes them
+from the deployment's remote config, so they are not restored automatically.
+Run `solo deployment port-forwards refresh --deployment one-shot` afterward to
+re-establish them.


### PR DESCRIPTION
**Description**:

This PR documents a new command in solo: `deployment port-forwards stop` and specifies the deprecation of `deployment refresh port-forwards` in favor of `deployment port-forwards refresh`.

**Related issue(s)**:

Related to [this PR in solo](https://github.com/hiero-ledger/solo/pull/5145)
Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
